### PR TITLE
Add failing test case for restoring unstaged changes

### DIFF
--- a/lib/overcommit/hook_context/pre_commit.rb
+++ b/lib/overcommit/hook_context/pre_commit.rb
@@ -18,9 +18,9 @@ module Overcommit::HookContext
       if !initial_commit? && any_changes?
         @stash_attempted = true
 
+        stash_message = "Overcommit: Stash of repo state before hook run at #{Time.now}"
         result = Overcommit::Utils.execute(
-          %w[git stash save --keep-index --quiet] +
-          ["Overcommit: Stash of repo state before hook run at #{Time.now}"]
+          %w[git stash save --keep-index --quiet] + [stash_message]
         )
 
         unless result.success?
@@ -31,8 +31,7 @@ module Overcommit::HookContext
                 "\nSTDOUT:#{result.stdout}\nSTDERR:#{result.stderr}"
         end
 
-        # False if only submodule references were changed
-        @changes_stashed = modified_files.any?
+        @changes_stashed = `git stash list -1`.include?(stash_message)
       end
 
       # While running the hooks make it appear as if nothing changed

--- a/spec/overcommit/hook_context/pre_commit_spec.rb
+++ b/spec/overcommit/hook_context/pre_commit_spec.rb
@@ -119,11 +119,19 @@ describe Overcommit::HookContext::PreCommit do
       around do |example|
         repo do
           `echo "Hello World" > tracked-file`
-          `git add tracked-file`
-          `git commit -m "Add tracked-file"`
+          `echo "Hello Other World" > other-tracked-file`
+          `git add tracked-file other-tracked-file`
+          `git commit -m "Add tracked-file and other-tracked-file"`
           `echo "Hello Again" > untracked-file`
+          `echo "Some more text" >> other-tracked-file`
           example.run
         end
+      end
+
+      it 'restores the unstaged changes' do
+        subject
+        File.open('other-tracked-file', 'r').read.
+          should == "Hello Other World\nSome more text\n"
       end
 
       it 'keeps already-committed files' do

--- a/spec/overcommit/hook_context/pre_commit_spec.rb
+++ b/spec/overcommit/hook_context/pre_commit_spec.rb
@@ -53,7 +53,7 @@ describe Overcommit::HookContext::PreCommit do
 
       it 'keeps staged changes' do
         subject
-        File.open('tracked-file', 'r').read.should == "Hello World\nSome more text\n"
+        `git show :tracked-file`.should == "Hello World\nSome more text\n"
       end
 
       it 'keeps untracked files' do
@@ -168,6 +168,11 @@ describe Overcommit::HookContext::PreCommit do
         subject
         File.open('tracked-file', 'r').read.
           should == "Hello World\nSome more text\nYet some more text\n"
+      end
+
+      it 'keeps staged changes' do
+        subject
+        `git show :tracked-file`.should == "Hello World\nSome more text\n"
       end
 
       it 'keeps untracked files' do


### PR DESCRIPTION
Add test case for `Overcommit::HookContext::PreCommit#cleanup_environment` to check that unstaged changes are restored when no changes were staged. This test is currently failing.

This is likely a regression introduced by #149. My bad. Fix incoming in a separate PR.