### PR TITLE
Fix missing method error in PushedRef#forced?

### DIFF
--- a/lib/overcommit/hook_context/pre_push.rb
+++ b/lib/overcommit/hook_context/pre_push.rb
@@ -19,7 +19,7 @@ module Overcommit::HookContext
 
     PushedRef = Struct.new(:local_ref, :local_sha1, :remote_ref, :remote_sha1) do
       def forced?
-        `git rev-list #{remote_sha1} ^#{local_sha1}`.chomp.any?
+        !(created? || deleted? || overwritten_commits.empty?)
       end
 
       def created?
@@ -32,6 +32,12 @@ module Overcommit::HookContext
 
       def to_s
         "#{local_ref} #{local_sha1} #{remote_ref} #{remote_sha1}"
+      end
+
+      private
+
+      def overwritten_commits
+        `git rev-list #{remote_sha1} ^#{local_sha1}`.split("\n")
       end
     end
   end


### PR DESCRIPTION
I was careless and didn't check whether String had a method `any?`. Thought it was `Enumerable` as in some other languages, but apparently not.

Also added specs for the `PushedRef` class.