### PR TITLE
Add Spellcheck commit-msg hook

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -40,6 +40,12 @@ CommitMsg:
   SingleLineSubject:
     description: 'Checking subject line'
 
+  Spellcheck:
+    enabled: false
+    description: 'Checking for misspelled words'
+    required_executable: 'hunspell'
+    flags: ['-a']
+
   TextWidth:
     description: 'Checking text width'
     max_subject_width: 60

--- a/lib/overcommit/hook/commit_msg/spellcheck.rb
+++ b/lib/overcommit/hook/commit_msg/spellcheck.rb
@@ -1,0 +1,37 @@
+require 'tempfile'
+
+module Overcommit::Hook::CommitMsg
+  # Checks the commit message for potential misspellings
+  class Spellcheck < Base
+    Misspelling = Struct.new(:word, :suggestions)
+
+    MISSPELLING_REGEX = /^[&#]\s(?<word>\w+)(?:.+?:\s(?<suggestions>.*))?/
+
+    def run
+      # Remove comments from commit message file
+      update_commit_message(commit_message)
+
+      result = execute(command + [commit_message_file])
+      return [:fail, "Error running spellcheck: #{result.stderr.chomp}"] unless result.success?
+
+      misspellings = parse_misspellings(result.stdout)
+      return :pass if misspellings.empty?
+
+      messages = misspellings.map do |misspelled|
+        msg = "Potential misspelling: #{misspelled.word}."
+        msg += " Suggestions: #{misspelled.suggestions}" unless misspelled.suggestions.nil?
+        msg
+      end
+
+      [:warn, messages.join("\n")]
+    end
+
+    private
+
+    def parse_misspellings(output)
+      output.scan(MISSPELLING_REGEX).map do |word, suggestions|
+        Misspelling.new(word, suggestions)
+      end
+    end
+  end
+end

--- a/spec/overcommit/hook/commit_msg/spellcheck_spec.rb
+++ b/spec/overcommit/hook/commit_msg/spellcheck_spec.rb
@@ -1,0 +1,76 @@
+# encoding: utf-8
+require 'spec_helper'
+
+describe Overcommit::Hook::CommitMsg::Spellcheck do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  before do
+    subject.stub(:update_commit_message)
+    subject.stub(:commit_message)
+    subject.stub(:commit_message_file)
+    subject.stub(:execute).and_return(result)
+  end
+
+  context 'when hunspell exits successfully' do
+    let(:result) { double('result') }
+
+    before do
+      result.stub(:success?).and_return(true)
+    end
+
+    context 'with no misspellings' do
+      before do
+        result.stub(:stdout).and_return(<<-EOS)
+@(#) International Ispell Version 3.2.06 (but really Hunspell 1.3.3)
+*
+*
+*
+        EOS
+      end
+
+      it { should pass }
+    end
+
+    context 'with misspellings' do
+      context 'with suggestions' do
+        before do
+          result.stub(:stdout).and_return(<<-EOS)
+@(#) International Ispell Version 3.2.06 (but really Hunspell 1.3.3)
+*
+& msg 10 4: MSG, mag, ms, mg, meg, mtg, mug, mpg, mfg, ms g
+*
+          EOS
+        end
+
+        it { should warn(/^Potential misspelling: \w+. Suggestions: .+$/) }
+      end
+
+      context 'with no suggestions' do
+        before do
+          result.stub(:stdout).and_return(<<-EOS)
+@(#) International Ispell Version 3.2.06 (but really Hunspell 1.3.3)
+*
+# supercalifragilisticexpialidocious 4
+*
+          EOS
+        end
+
+        it { should warn(/^Potential misspelling: \w+.$/) }
+      end
+    end
+  end
+
+  context 'when hunspell exits unsuccessfully' do
+    let(:result) { double('result') }
+
+    before do
+      result.stub(success?: false, stderr: <<-EOS)
+Can't open affix or dictionary files for dictionary named "foo".
+      EOS
+    end
+
+    it { should fail_hook }
+  end
+end

--- a/spec/overcommit/hook/commit_msg/spellcheck_spec.rb
+++ b/spec/overcommit/hook/commit_msg/spellcheck_spec.rb
@@ -7,9 +7,7 @@ describe Overcommit::Hook::CommitMsg::Spellcheck do
   subject { described_class.new(config, context) }
 
   before do
-    subject.stub(:update_commit_message)
-    subject.stub(:commit_message)
-    subject.stub(:commit_message_file)
+    subject.stub(:uncommented_commit_msg_file)
     subject.stub(:execute).and_return(result)
   end
 


### PR DESCRIPTION
This hook uses [hunspell](http://hunspell.sourceforge.net/) to check the commit message for potential misspellings, and suggests alternate spellings if available.