### PR TITLE
Add SubmoduleStatus post-checkout, post-commit, post-merge, and post-rewrite hooks

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -490,6 +490,12 @@ PostRewrite:
     description: 'Generating tags file from source'
     required_executable: 'ctags'
 
+  SubmoduleStatus:
+    enabled: false
+    description: 'Checking submodule status'
+    required_executable: 'git'
+    flags: ['submodule', 'status']
+
 # Hooks that run during `git push`, after remote refs have been updated but
 # before any objects have been transferred.
 PrePush:

--- a/config/default.yml
+++ b/config/default.yml
@@ -473,6 +473,12 @@ PostMerge:
     description: 'Generating tags file from source'
     required_executable: 'ctags'
 
+  SubmoduleStatus:
+    enabled: false
+    description: 'Checking submodule status'
+    required_executable: 'git'
+    flags: ['submodule', 'status']
+
 # Hooks that run after a commit is modified by an amend or rebase.
 PostRewrite:
   ALL:

--- a/config/default.yml
+++ b/config/default.yml
@@ -430,6 +430,12 @@ PostCheckout:
     description: 'Generating tags file from source'
     required_executable: 'ctags'
 
+  SubmoduleStatus:
+    enabled: false
+    description: 'Checking submodule status'
+    required_executable: 'git'
+    flags: ['submodule', 'status']
+
 # Hooks that run after a commit is created.
 PostCommit:
   ALL:

--- a/config/default.yml
+++ b/config/default.yml
@@ -433,8 +433,7 @@ PostCheckout:
   SubmoduleStatus:
     enabled: false
     description: 'Checking submodule status'
-    required_executable: 'git'
-    flags: ['submodule', 'status']
+    recursive: false
 
 # Hooks that run after a commit is created.
 PostCommit:
@@ -459,8 +458,7 @@ PostCommit:
   SubmoduleStatus:
     enabled: false
     description: 'Checking submodule status'
-    required_executable: 'git'
-    flags: ['submodule', 'status']
+    recursive: false
 
 # Hooks that run after `git merge` executes successfully (no merge conflicts).
 PostMerge:
@@ -476,8 +474,7 @@ PostMerge:
   SubmoduleStatus:
     enabled: false
     description: 'Checking submodule status'
-    required_executable: 'git'
-    flags: ['submodule', 'status']
+    recursive: false
 
 # Hooks that run after a commit is modified by an amend or rebase.
 PostRewrite:
@@ -493,8 +490,7 @@ PostRewrite:
   SubmoduleStatus:
     enabled: false
     description: 'Checking submodule status'
-    required_executable: 'git'
-    flags: ['submodule', 'status']
+    recursive: false
 
 # Hooks that run during `git push`, after remote refs have been updated but
 # before any objects have been transferred.

--- a/config/default.yml
+++ b/config/default.yml
@@ -456,6 +456,12 @@ PostCommit:
     description: 'Generating tags file from source'
     required_executable: 'ctags'
 
+  SubmoduleStatus:
+    enabled: false
+    description: 'Checking submodule status'
+    required_executable: 'git'
+    flags: ['submodule', 'status']
+
 # Hooks that run after `git merge` executes successfully (no merge conflicts).
 PostMerge:
   ALL:

--- a/config/default.yml
+++ b/config/default.yml
@@ -433,6 +433,7 @@ PostCheckout:
   SubmoduleStatus:
     enabled: false
     description: 'Checking submodule status'
+    quiet: true
     recursive: false
 
 # Hooks that run after a commit is created.
@@ -458,6 +459,7 @@ PostCommit:
   SubmoduleStatus:
     enabled: false
     description: 'Checking submodule status'
+    quiet: true
     recursive: false
 
 # Hooks that run after `git merge` executes successfully (no merge conflicts).
@@ -474,6 +476,7 @@ PostMerge:
   SubmoduleStatus:
     enabled: false
     description: 'Checking submodule status'
+    quiet: true
     recursive: false
 
 # Hooks that run after a commit is modified by an amend or rebase.
@@ -490,6 +493,7 @@ PostRewrite:
   SubmoduleStatus:
     enabled: false
     description: 'Checking submodule status'
+    quiet: true
     recursive: false
 
 # Hooks that run during `git push`, after remote refs have been updated but

--- a/lib/overcommit/hook/post_checkout/submodule_status.rb
+++ b/lib/overcommit/hook/post_checkout/submodule_status.rb
@@ -3,30 +3,7 @@ module Overcommit::Hook::PostCheckout
   # notifies the user if any are uninitialized, out of date with
   # the current index, or contain merge conflicts.
   class SubmoduleStatus < Base
-    SUBMODULE_STATUS_REGEX = /
-      ^\s*(?<prefix>[-+U]?)(?<sha1>\w+)
-      \s(?<path>[^\s]+?)
-      (?:\s\((?<describe>.+)\))?$
-    /x
-
-    SubmoduleStatus = Struct.new(:prefix, :sha1, :path, :describe) do
-      def uninitialized?
-        prefix == '-'
-      end
-
-      def outdated?
-        prefix == '+'
-      end
-
-      def merge_conflict?
-        prefix == 'U'
-      end
-    end
-
     def run
-      result = execute(command)
-      submodule_statuses = parse_submodule_statuses(result.stdout)
-
       messages = []
       submodule_statuses.each do |submodule_status|
         path = submodule_status.path
@@ -46,10 +23,8 @@ module Overcommit::Hook::PostCheckout
 
     private
 
-    def parse_submodule_statuses(output)
-      output.scan(SUBMODULE_STATUS_REGEX).map do |prefix, sha1, path, describe|
-        SubmoduleStatus.new(prefix, sha1, path, describe)
-      end
+    def submodule_statuses
+      Overcommit::GitRepo.submodule_statuses(recursive: config['recursive'])
     end
   end
 end

--- a/lib/overcommit/hook/post_checkout/submodule_status.rb
+++ b/lib/overcommit/hook/post_checkout/submodule_status.rb
@@ -1,0 +1,55 @@
+module Overcommit::Hook::PostCheckout
+  # Checks the status of submodules in the current repository and
+  # notifies the user if any are uninitialized, out of date with
+  # the current index, or contain merge conflicts.
+  class SubmoduleStatus < Base
+    SUBMODULE_STATUS_REGEX = /
+      ^\s*(?<prefix>[-+U]?)(?<sha1>\w+)
+      \s(?<path>[^\s]+?)
+      (?:\s\((?<describe>.+)\))?$
+    /x
+
+    SubmoduleStatus = Struct.new(:prefix, :sha1, :path, :describe) do
+      def uninitialized?
+        prefix == '-'
+      end
+
+      def outdated?
+        prefix == '+'
+      end
+
+      def merge_conflict?
+        prefix == 'U'
+      end
+    end
+
+    def run
+      result = execute(command)
+      submodule_statuses = parse_submodule_statuses(result.stdout)
+
+      messages = []
+      submodule_statuses.each do |submodule_status|
+        path = submodule_status.path
+        if submodule_status.uninitialized?
+          messages << "Submodule #{path} is uninitialized."
+        elsif submodule_status.outdated?
+          messages << "Submodule #{path} is out of date with the current index."
+        elsif submodule_status.merge_conflict?
+          messages << "Submodule #{path} has merge conflicts."
+        end
+      end
+
+      return :pass if messages.empty?
+
+      [:warn, messages.join("\n")]
+    end
+
+    private
+
+    def parse_submodule_statuses(output)
+      output.scan(SUBMODULE_STATUS_REGEX).map do |prefix, sha1, path, describe|
+        SubmoduleStatus.new(prefix, sha1, path, describe)
+      end
+    end
+  end
+end

--- a/lib/overcommit/hook/post_commit/submodule_status.rb
+++ b/lib/overcommit/hook/post_commit/submodule_status.rb
@@ -1,0 +1,55 @@
+module Overcommit::Hook::PostCommit
+  # Checks the status of submodules in the current repository and
+  # notifies the user if any are uninitialized, out of date with
+  # the current index, or contain merge conflicts.
+  class SubmoduleStatus < Base
+    SUBMODULE_STATUS_REGEX = /
+      ^\s*(?<prefix>[-+U]?)(?<sha1>\w+)
+      \s(?<path>[^\s]+?)
+      (?:\s\((?<describe>.+)\))?$
+    /x
+
+    SubmoduleStatus = Struct.new(:prefix, :sha1, :path, :describe) do
+      def uninitialized?
+        prefix == '-'
+      end
+
+      def outdated?
+        prefix == '+'
+      end
+
+      def merge_conflict?
+        prefix == 'U'
+      end
+    end
+
+    def run
+      result = execute(command)
+      submodule_statuses = parse_submodule_statuses(result.stdout)
+
+      messages = []
+      submodule_statuses.each do |submodule_status|
+        path = submodule_status.path
+        if submodule_status.uninitialized?
+          messages << "Submodule #{path} is uninitialized."
+        elsif submodule_status.outdated?
+          messages << "Submodule #{path} is out of date with the current index."
+        elsif submodule_status.merge_conflict?
+          messages << "Submodule #{path} has merge conflicts."
+        end
+      end
+
+      return :pass if messages.empty?
+
+      [:warn, messages.join("\n")]
+    end
+
+    private
+
+    def parse_submodule_statuses(output)
+      output.scan(SUBMODULE_STATUS_REGEX).map do |prefix, sha1, path, describe|
+        SubmoduleStatus.new(prefix, sha1, path, describe)
+      end
+    end
+  end
+end

--- a/lib/overcommit/hook/post_merge/submodule_status.rb
+++ b/lib/overcommit/hook/post_merge/submodule_status.rb
@@ -3,30 +3,7 @@ module Overcommit::Hook::PostMerge
   # notifies the user if any are uninitialized, out of date with
   # the current index, or contain merge conflicts.
   class SubmoduleStatus < Base
-    SUBMODULE_STATUS_REGEX = /
-      ^\s*(?<prefix>[-+U]?)(?<sha1>\w+)
-      \s(?<path>[^\s]+?)
-      (?:\s\((?<describe>.+)\))?$
-    /x
-
-    SubmoduleStatus = Struct.new(:prefix, :sha1, :path, :describe) do
-      def uninitialized?
-        prefix == '-'
-      end
-
-      def outdated?
-        prefix == '+'
-      end
-
-      def merge_conflict?
-        prefix == 'U'
-      end
-    end
-
     def run
-      result = execute(command)
-      submodule_statuses = parse_submodule_statuses(result.stdout)
-
       messages = []
       submodule_statuses.each do |submodule_status|
         path = submodule_status.path
@@ -46,10 +23,8 @@ module Overcommit::Hook::PostMerge
 
     private
 
-    def parse_submodule_statuses(output)
-      output.scan(SUBMODULE_STATUS_REGEX).map do |prefix, sha1, path, describe|
-        SubmoduleStatus.new(prefix, sha1, path, describe)
-      end
+    def submodule_statuses
+      Overcommit::GitRepo.submodule_statuses(recursive: config['recursive'])
     end
   end
 end

--- a/lib/overcommit/hook/post_merge/submodule_status.rb
+++ b/lib/overcommit/hook/post_merge/submodule_status.rb
@@ -1,0 +1,55 @@
+module Overcommit::Hook::PostMerge
+  # Checks the status of submodules in the current repository and
+  # notifies the user if any are uninitialized, out of date with
+  # the current index, or contain merge conflicts.
+  class SubmoduleStatus < Base
+    SUBMODULE_STATUS_REGEX = /
+      ^\s*(?<prefix>[-+U]?)(?<sha1>\w+)
+      \s(?<path>[^\s]+?)
+      (?:\s\((?<describe>.+)\))?$
+    /x
+
+    SubmoduleStatus = Struct.new(:prefix, :sha1, :path, :describe) do
+      def uninitialized?
+        prefix == '-'
+      end
+
+      def outdated?
+        prefix == '+'
+      end
+
+      def merge_conflict?
+        prefix == 'U'
+      end
+    end
+
+    def run
+      result = execute(command)
+      submodule_statuses = parse_submodule_statuses(result.stdout)
+
+      messages = []
+      submodule_statuses.each do |submodule_status|
+        path = submodule_status.path
+        if submodule_status.uninitialized?
+          messages << "Submodule #{path} is uninitialized."
+        elsif submodule_status.outdated?
+          messages << "Submodule #{path} is out of date with the current index."
+        elsif submodule_status.merge_conflict?
+          messages << "Submodule #{path} has merge conflicts."
+        end
+      end
+
+      return :pass if messages.empty?
+
+      [:warn, messages.join("\n")]
+    end
+
+    private
+
+    def parse_submodule_statuses(output)
+      output.scan(SUBMODULE_STATUS_REGEX).map do |prefix, sha1, path, describe|
+        SubmoduleStatus.new(prefix, sha1, path, describe)
+      end
+    end
+  end
+end

--- a/lib/overcommit/hook/post_rewrite/submodule_status.rb
+++ b/lib/overcommit/hook/post_rewrite/submodule_status.rb
@@ -1,0 +1,55 @@
+module Overcommit::Hook::PostRewrite
+  # Checks the status of submodules in the current repository and
+  # notifies the user if any are uninitialized, out of date with
+  # the current index, or contain merge conflicts.
+  class SubmoduleStatus < Base
+    SUBMODULE_STATUS_REGEX = /
+      ^\s*(?<prefix>[-+U]?)(?<sha1>\w+)
+      \s(?<path>[^\s]+?)
+      (?:\s\((?<describe>.+)\))?$
+    /x
+
+    SubmoduleStatus = Struct.new(:prefix, :sha1, :path, :describe) do
+      def uninitialized?
+        prefix == '-'
+      end
+
+      def outdated?
+        prefix == '+'
+      end
+
+      def merge_conflict?
+        prefix == 'U'
+      end
+    end
+
+    def run
+      result = execute(command)
+      submodule_statuses = parse_submodule_statuses(result.stdout)
+
+      messages = []
+      submodule_statuses.each do |submodule_status|
+        path = submodule_status.path
+        if submodule_status.uninitialized?
+          messages << "Submodule #{path} is uninitialized."
+        elsif submodule_status.outdated?
+          messages << "Submodule #{path} is out of date with the current index."
+        elsif submodule_status.merge_conflict?
+          messages << "Submodule #{path} has merge conflicts."
+        end
+      end
+
+      return :pass if messages.empty?
+
+      [:warn, messages.join("\n")]
+    end
+
+    private
+
+    def parse_submodule_statuses(output)
+      output.scan(SUBMODULE_STATUS_REGEX).map do |prefix, sha1, path, describe|
+        SubmoduleStatus.new(prefix, sha1, path, describe)
+      end
+    end
+  end
+end

--- a/lib/overcommit/hook/post_rewrite/submodule_status.rb
+++ b/lib/overcommit/hook/post_rewrite/submodule_status.rb
@@ -3,30 +3,7 @@ module Overcommit::Hook::PostRewrite
   # notifies the user if any are uninitialized, out of date with
   # the current index, or contain merge conflicts.
   class SubmoduleStatus < Base
-    SUBMODULE_STATUS_REGEX = /
-      ^\s*(?<prefix>[-+U]?)(?<sha1>\w+)
-      \s(?<path>[^\s]+?)
-      (?:\s\((?<describe>.+)\))?$
-    /x
-
-    SubmoduleStatus = Struct.new(:prefix, :sha1, :path, :describe) do
-      def uninitialized?
-        prefix == '-'
-      end
-
-      def outdated?
-        prefix == '+'
-      end
-
-      def merge_conflict?
-        prefix == 'U'
-      end
-    end
-
     def run
-      result = execute(command)
-      submodule_statuses = parse_submodule_statuses(result.stdout)
-
       messages = []
       submodule_statuses.each do |submodule_status|
         path = submodule_status.path
@@ -46,10 +23,8 @@ module Overcommit::Hook::PostRewrite
 
     private
 
-    def parse_submodule_statuses(output)
-      output.scan(SUBMODULE_STATUS_REGEX).map do |prefix, sha1, path, describe|
-        SubmoduleStatus.new(prefix, sha1, path, describe)
-      end
+    def submodule_statuses
+      Overcommit::GitRepo.submodule_statuses(recursive: config['recursive'])
     end
   end
 end

--- a/spec/overcommit/hook/post_checkout/submodule_status_spec.rb
+++ b/spec/overcommit/hook/post_checkout/submodule_status_spec.rb
@@ -5,33 +5,49 @@ describe Overcommit::Hook::PostCheckout::SubmoduleStatus do
   let(:context) { double('context') }
   subject { described_class.new(config, context) }
 
-  let(:result) { double('result') }
+  let(:submodule_status) { double('submodule_status') }
 
   before do
-    result.stub(:stdout).and_return("#{prefix}#{random_hash} sub (heads/master)")
-    subject.stub(:execute).and_return(result)
+    submodule_status.stub(:path).and_return('sub')
+    subject.stub(:submodule_statuses).and_return([submodule_status])
   end
 
   context 'when submodule is up to date' do
-    let(:prefix) { '' }
+    before do
+      submodule_status.stub(uninitialized?: false,
+                            outdated?: false,
+                            merge_conflict?: false)
+    end
 
     it { should pass }
   end
 
   context 'when submodule is uninitialized' do
-    let(:prefix) { '-' }
+    before do
+      submodule_status.stub(uninitialized?: true,
+                            outdated?: false,
+                            merge_conflict?: false)
+    end
 
     it { should warn(/uninitialized/) }
   end
 
   context 'when submodule is outdated' do
-    let(:prefix) { '+' }
+    before do
+      submodule_status.stub(uninitialized?: false,
+                            outdated?: true,
+                            merge_conflict?: false)
+    end
 
     it { should warn(/out of date/) }
   end
 
   context 'when submodule has merge conflicts' do
-    let(:prefix) { 'U' }
+    before do
+      submodule_status.stub(uninitialized?: false,
+                            outdated?: false,
+                            merge_conflict?: true)
+    end
 
     it { should warn(/merge conflicts/) }
   end

--- a/spec/overcommit/hook/post_checkout/submodule_status_spec.rb
+++ b/spec/overcommit/hook/post_checkout/submodule_status_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PostCheckout::SubmoduleStatus do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  let(:result) { double('result') }
+
+  before do
+    result.stub(:stdout).and_return("#{prefix}#{random_hash} sub (heads/master)")
+    subject.stub(:execute).and_return(result)
+  end
+
+  context 'when submodule is up to date' do
+    let(:prefix) { '' }
+
+    it { should pass }
+  end
+
+  context 'when submodule is uninitialized' do
+    let(:prefix) { '-' }
+
+    it { should warn(/uninitialized/) }
+  end
+
+  context 'when submodule is outdated' do
+    let(:prefix) { '+' }
+
+    it { should warn(/out of date/) }
+  end
+
+  context 'when submodule has merge conflicts' do
+    let(:prefix) { 'U' }
+
+    it { should warn(/merge conflicts/) }
+  end
+end

--- a/spec/overcommit/hook/post_commit/submodule_status_spec.rb
+++ b/spec/overcommit/hook/post_commit/submodule_status_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PostCommit::SubmoduleStatus do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  let(:result) { double('result') }
+
+  before do
+    result.stub(:stdout).and_return("#{prefix}#{random_hash} sub (heads/master)")
+    subject.stub(:execute).and_return(result)
+  end
+
+  context 'when submodule is up to date' do
+    let(:prefix) { '' }
+
+    it { should pass }
+  end
+
+  context 'when submodule is uninitialized' do
+    let(:prefix) { '-' }
+
+    it { should warn(/uninitialized/) }
+  end
+
+  context 'when submodule is outdated' do
+    let(:prefix) { '+' }
+
+    it { should warn(/out of date/) }
+  end
+
+  context 'when submodule has merge conflicts' do
+    let(:prefix) { 'U' }
+
+    it { should warn(/merge conflicts/) }
+  end
+end

--- a/spec/overcommit/hook/post_commit/submodule_status_spec.rb
+++ b/spec/overcommit/hook/post_commit/submodule_status_spec.rb
@@ -5,33 +5,49 @@ describe Overcommit::Hook::PostCommit::SubmoduleStatus do
   let(:context) { double('context') }
   subject { described_class.new(config, context) }
 
-  let(:result) { double('result') }
+  let(:submodule_status) { double('submodule_status') }
 
   before do
-    result.stub(:stdout).and_return("#{prefix}#{random_hash} sub (heads/master)")
-    subject.stub(:execute).and_return(result)
+    submodule_status.stub(:path).and_return('sub')
+    subject.stub(:submodule_statuses).and_return([submodule_status])
   end
 
   context 'when submodule is up to date' do
-    let(:prefix) { '' }
+    before do
+      submodule_status.stub(uninitialized?: false,
+                            outdated?: false,
+                            merge_conflict?: false)
+    end
 
     it { should pass }
   end
 
   context 'when submodule is uninitialized' do
-    let(:prefix) { '-' }
+    before do
+      submodule_status.stub(uninitialized?: true,
+                            outdated?: false,
+                            merge_conflict?: false)
+    end
 
     it { should warn(/uninitialized/) }
   end
 
   context 'when submodule is outdated' do
-    let(:prefix) { '+' }
+    before do
+      submodule_status.stub(uninitialized?: false,
+                            outdated?: true,
+                            merge_conflict?: false)
+    end
 
     it { should warn(/out of date/) }
   end
 
   context 'when submodule has merge conflicts' do
-    let(:prefix) { 'U' }
+    before do
+      submodule_status.stub(uninitialized?: false,
+                            outdated?: false,
+                            merge_conflict?: true)
+    end
 
     it { should warn(/merge conflicts/) }
   end

--- a/spec/overcommit/hook/post_merge/submodule_status_spec.rb
+++ b/spec/overcommit/hook/post_merge/submodule_status_spec.rb
@@ -5,33 +5,49 @@ describe Overcommit::Hook::PostMerge::SubmoduleStatus do
   let(:context) { double('context') }
   subject { described_class.new(config, context) }
 
-  let(:result) { double('result') }
+  let(:submodule_status) { double('submodule_status') }
 
   before do
-    result.stub(:stdout).and_return("#{prefix}#{random_hash} sub (heads/master)")
-    subject.stub(:execute).and_return(result)
+    submodule_status.stub(:path).and_return('sub')
+    subject.stub(:submodule_statuses).and_return([submodule_status])
   end
 
   context 'when submodule is up to date' do
-    let(:prefix) { '' }
+    before do
+      submodule_status.stub(uninitialized?: false,
+                            outdated?: false,
+                            merge_conflict?: false)
+    end
 
     it { should pass }
   end
 
   context 'when submodule is uninitialized' do
-    let(:prefix) { '-' }
+    before do
+      submodule_status.stub(uninitialized?: true,
+                            outdated?: false,
+                            merge_conflict?: false)
+    end
 
     it { should warn(/uninitialized/) }
   end
 
   context 'when submodule is outdated' do
-    let(:prefix) { '+' }
+    before do
+      submodule_status.stub(uninitialized?: false,
+                            outdated?: true,
+                            merge_conflict?: false)
+    end
 
     it { should warn(/out of date/) }
   end
 
   context 'when submodule has merge conflicts' do
-    let(:prefix) { 'U' }
+    before do
+      submodule_status.stub(uninitialized?: false,
+                            outdated?: false,
+                            merge_conflict?: true)
+    end
 
     it { should warn(/merge conflicts/) }
   end

--- a/spec/overcommit/hook/post_merge/submodule_status_spec.rb
+++ b/spec/overcommit/hook/post_merge/submodule_status_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PostMerge::SubmoduleStatus do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  let(:result) { double('result') }
+
+  before do
+    result.stub(:stdout).and_return("#{prefix}#{random_hash} sub (heads/master)")
+    subject.stub(:execute).and_return(result)
+  end
+
+  context 'when submodule is up to date' do
+    let(:prefix) { '' }
+
+    it { should pass }
+  end
+
+  context 'when submodule is uninitialized' do
+    let(:prefix) { '-' }
+
+    it { should warn(/uninitialized/) }
+  end
+
+  context 'when submodule is outdated' do
+    let(:prefix) { '+' }
+
+    it { should warn(/out of date/) }
+  end
+
+  context 'when submodule has merge conflicts' do
+    let(:prefix) { 'U' }
+
+    it { should warn(/merge conflicts/) }
+  end
+end

--- a/spec/overcommit/hook/post_rewrite/submodule_status_spec.rb
+++ b/spec/overcommit/hook/post_rewrite/submodule_status_spec.rb
@@ -5,33 +5,49 @@ describe Overcommit::Hook::PostRewrite::SubmoduleStatus do
   let(:context) { double('context') }
   subject { described_class.new(config, context) }
 
-  let(:result) { double('result') }
+  let(:submodule_status) { double('submodule_status') }
 
   before do
-    result.stub(:stdout).and_return("#{prefix}#{random_hash} sub (heads/master)")
-    subject.stub(:execute).and_return(result)
+    submodule_status.stub(:path).and_return('sub')
+    subject.stub(:submodule_statuses).and_return([submodule_status])
   end
 
   context 'when submodule is up to date' do
-    let(:prefix) { '' }
+    before do
+      submodule_status.stub(uninitialized?: false,
+                            outdated?: false,
+                            merge_conflict?: false)
+    end
 
     it { should pass }
   end
 
   context 'when submodule is uninitialized' do
-    let(:prefix) { '-' }
+    before do
+      submodule_status.stub(uninitialized?: true,
+                            outdated?: false,
+                            merge_conflict?: false)
+    end
 
     it { should warn(/uninitialized/) }
   end
 
   context 'when submodule is outdated' do
-    let(:prefix) { '+' }
+    before do
+      submodule_status.stub(uninitialized?: false,
+                            outdated?: true,
+                            merge_conflict?: false)
+    end
 
     it { should warn(/out of date/) }
   end
 
   context 'when submodule has merge conflicts' do
-    let(:prefix) { 'U' }
+    before do
+      submodule_status.stub(uninitialized?: false,
+                            outdated?: false,
+                            merge_conflict?: true)
+    end
 
     it { should warn(/merge conflicts/) }
   end

--- a/spec/overcommit/hook/post_rewrite/submodule_status_spec.rb
+++ b/spec/overcommit/hook/post_rewrite/submodule_status_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PostRewrite::SubmoduleStatus do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  let(:result) { double('result') }
+
+  before do
+    result.stub(:stdout).and_return("#{prefix}#{random_hash} sub (heads/master)")
+    subject.stub(:execute).and_return(result)
+  end
+
+  context 'when submodule is up to date' do
+    let(:prefix) { '' }
+
+    it { should pass }
+  end
+
+  context 'when submodule is uninitialized' do
+    let(:prefix) { '-' }
+
+    it { should warn(/uninitialized/) }
+  end
+
+  context 'when submodule is outdated' do
+    let(:prefix) { '+' }
+
+    it { should warn(/out of date/) }
+  end
+
+  context 'when submodule has merge conflicts' do
+    let(:prefix) { 'U' }
+
+    it { should warn(/merge conflicts/) }
+  end
+end


### PR DESCRIPTION
These hooks warn of any submodules that are uninitialized, out of date with the current index, or contain merge conflicts.

To check submodules recursively, just set `flags: ['--recursive']` in the config.

Closes #145