### PR TITLE
Extract process logic from `Utils.execute_in_background` into `Subprocess.spawn_detached`

### DIFF
--- a/lib/overcommit/subprocess.rb
+++ b/lib/overcommit/subprocess.rb
@@ -31,14 +31,9 @@ module Overcommit
 
       # Spawns a new process in the background using the given array of
       # arguments (the first element is the command).
-      #
-      # @return [ChildProcess]
-      def spawn_in_background(args)
-        process = ChildProcess.build(*args)
-
-        assign_output_streams(process)
-
-        process.start
+      def spawn_detached(args)
+        # Dissociate process from parent's input/output streams
+        Process.detach(Process.spawn({}, *args, [:in, :out, :err] => '/dev/null'))
       end
 
       private

--- a/lib/overcommit/subprocess.rb
+++ b/lib/overcommit/subprocess.rb
@@ -29,6 +29,18 @@ module Overcommit
         Result.new(process.exit_code, out.read, err.read)
       end
 
+      # Spawns a new process in the background using the given array of
+      # arguments (the first element is the command).
+      #
+      # @return [ChildProcess]
+      def spawn_in_background(args)
+        process = ChildProcess.build(*args)
+
+        assign_output_streams(process)
+
+        process.start
+      end
+
       private
 
       # @param process [ChildProcess]

--- a/lib/overcommit/utils.rb
+++ b/lib/overcommit/utils.rb
@@ -124,14 +124,14 @@ module Overcommit
       # which we do not need to know the result.
       #
       # @param args [Array<String>]
-      # @return [ChildProcess] thread watching the resulting child process
+      # @return [Thread] thread watching the resulting child process
       def execute_in_background(args)
         if args.include?('|')
           raise Overcommit::Exceptions::InvalidCommandArgs,
                 'Cannot pipe commands with the `execute_in_background` helper'
         end
 
-        Subprocess.spawn_in_background(args)
+        Subprocess.spawn_detached(args)
       end
 
       # Calls a block of code with a modified set of environment variables,

--- a/lib/overcommit/utils.rb
+++ b/lib/overcommit/utils.rb
@@ -124,15 +124,14 @@ module Overcommit
       # which we do not need to know the result.
       #
       # @param args [Array<String>]
-      # @return [Thread] thread watching the resulting child process
+      # @return [ChildProcess] thread watching the resulting child process
       def execute_in_background(args)
         if args.include?('|')
           raise Overcommit::Exceptions::InvalidCommandArgs,
                 'Cannot pipe commands with the `execute_in_background` helper'
         end
 
-        # Dissociate process from parent's input/output streams
-        Process.detach(Process.spawn({}, *args, [:in, :out, :err] => '/dev/null'))
+        Subprocess.spawn_in_background(args)
       end
 
       # Calls a block of code with a modified set of environment variables,

--- a/spec/overcommit/utils_spec.rb
+++ b/spec/overcommit/utils_spec.rb
@@ -153,7 +153,7 @@ describe Overcommit::Utils do
     end
 
     it 'executes the command' do
-      wait_until { subject.stop? } # Make sure process terminated before checking
+      wait_until { subject.exited? } # Make sure process terminated before checking
       File.exist?('some-file').should == true
     end
   end

--- a/spec/overcommit/utils_spec.rb
+++ b/spec/overcommit/utils_spec.rb
@@ -153,7 +153,7 @@ describe Overcommit::Utils do
     end
 
     it 'executes the command' do
-      wait_until { subject.exited? } # Make sure process terminated before checking
+      wait_until { subject.stop? } # Make sure process terminated before checking
       File.exist?('some-file').should == true
     end
   end


### PR DESCRIPTION
Move process logic from `Utils.execute_in_background` to `Subprocess.spawn_in_background`. Use `ChildProcess` rather than low-level `Process` module for future-proofing, since `ChildProcess` is Windows-compatible.

Edit: Per the conversation in the comments, this PR now simply extracts the `Process.detach(Process.spawn(...))` logic to `Subprocess.spawn_detached` in the interest of separation of concerns.