### PR TITLE
Use ChildProcess to spawn detached processes

### DIFF
--- a/lib/overcommit/subprocess.rb
+++ b/lib/overcommit/subprocess.rb
@@ -32,8 +32,12 @@ module Overcommit
       # Spawns a new process in the background using the given array of
       # arguments (the first element is the command).
       def spawn_detached(args)
-        # Dissociate process from parent's input/output streams
-        Process.detach(Process.spawn({}, *args, [:in, :out, :err] => '/dev/null'))
+        process = ChildProcess.build(*args)
+        process.detach = true
+
+        assign_output_streams(process)
+
+        process.start
       end
 
       private

--- a/lib/overcommit/utils.rb
+++ b/lib/overcommit/utils.rb
@@ -124,7 +124,7 @@ module Overcommit
       # which we do not need to know the result.
       #
       # @param args [Array<String>]
-      # @return [Thread] thread watching the resulting child process
+      # @return [ChildProcess] detached process spawned in the background
       def execute_in_background(args)
         if args.include?('|')
           raise Overcommit::Exceptions::InvalidCommandArgs,

--- a/spec/overcommit/utils_spec.rb
+++ b/spec/overcommit/utils_spec.rb
@@ -153,7 +153,7 @@ describe Overcommit::Utils do
     end
 
     it 'executes the command' do
-      wait_until { subject.stop? } # Make sure process terminated before checking
+      wait_until { subject.exited? } # Make sure process terminated before checking
       File.exist?('some-file').should == true
     end
   end


### PR DESCRIPTION
As of [childprocess v0.5.6](https://github.com/jarib/childprocess/commit/14a0d30b0dd5d12808709fa1d82080f12c2e3f99), it is possible to check the exit status of a ChildProcess without an error being thrown.