### PR TITLE
Add #amendment? delegator to Hook::PreCommit::Base

### DIFF
--- a/lib/overcommit/hook/pre_commit/base.rb
+++ b/lib/overcommit/hook/pre_commit/base.rb
@@ -5,7 +5,7 @@ module Overcommit::Hook::PreCommit
   class Base < Overcommit::Hook::Base
     extend Forwardable
 
-    def_delegators :@context, :modified_lines_in_file
+    def_delegators :@context, :modified_lines_in_file, :amendment?
 
     private
 


### PR DESCRIPTION
This makes it easier for pre-commit hooks to check whether the hook run was triggered by an amendment.