### PR TITLE
Add **/*.svg to ImageOptim default include configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Overcommit Changelog
 
+## master (unreleased)
+
+* Add `**/*.svg` to `ImageOptim` default includes configuration
+
 ## 0.24.0
 
 ### New Features

--- a/config/default.yml
+++ b/config/default.yml
@@ -204,9 +204,10 @@ PreCommit:
     install_command: 'gem install image_optim'
     include:
       - '**/*.gif'
-      - '**/*.jpg'
       - '**/*.jpeg'
+      - '**/*.jpg'
       - '**/*.png'
+      - '**/*.svg'
 
   JavaCheckstyle:
     enabled: false


### PR DESCRIPTION
The image_optim gem can run on SVG files, so we may as well include them
here.