### PR TITLE
Make IndexTags quiet by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Overcommit Changelog
 
+## master (unreleased)
+
+* Make `IndexTags` quiet by default
+
 ## 0.24.0
 
 ### New Features

--- a/config/default.yml
+++ b/config/default.yml
@@ -453,6 +453,7 @@ PostCheckout:
   IndexTags:
     enabled: false
     description: 'Generating tags file from source'
+    quiet: true
     required_executable: 'ctags'
 
   SubmoduleStatus:
@@ -479,6 +480,7 @@ PostCommit:
   IndexTags:
     enabled: false
     description: 'Generating tags file from source'
+    quiet: true
     required_executable: 'ctags'
 
   SubmoduleStatus:
@@ -496,6 +498,7 @@ PostMerge:
   IndexTags:
     enabled: false
     description: 'Generating tags file from source'
+    quiet: true
     required_executable: 'ctags'
 
   SubmoduleStatus:
@@ -513,6 +516,7 @@ PostRewrite:
   IndexTags:
     enabled: false
     description: 'Generating tags file from source'
+    quiet: true
     required_executable: 'ctags'
 
   SubmoduleStatus:


### PR DESCRIPTION
The output of this hook is never important. Making it quiet by default
will help people focus on more important overcommit output.