### PR TITLE
Don't include trailing period in GIT_VERSION

### DIFF
--- a/lib/overcommit/git_version.rb
+++ b/lib/overcommit/git_version.rb
@@ -9,7 +9,7 @@
 #   end
 module Overcommit
   GIT_VERSION = begin
-    version = `git --version`.chomp[/[\d\.]+/, 0]
+    version = `git --version`.chomp[/\d+(\.\d+)+/, 0]
     Overcommit::Utils::Version.new(version)
   end
 end


### PR DESCRIPTION
This prevents something like `1.9.5.msysgit` from being extracted as `1.9.5.`, which causes `Gem::Version.new` to throw an error.