### PR TITLE
Use overcommit CLI for integration tests

### DIFF
--- a/spec/integration/committing_spec.rb
+++ b/spec/integration/committing_spec.rb
@@ -17,8 +17,7 @@ describe 'commiting' do
   around do |example|
     repo do
       File.open('.overcommit.yml', 'w') { |f| f.write(config) }
-      Overcommit::Installer.new(Overcommit::Logger.silent).
-                            run('.', action: :install)
+      `overcommit --install > #{File::NULL}`
       example.run
     end
   end
@@ -60,8 +59,7 @@ describe 'commiting to an empty repo' do
 
   around do |example|
     repo do
-      Overcommit::Installer.new(Overcommit::Logger.silent).
-                            run('.', action: :install)
+      `overcommit --install > #{File::NULL}`
       File.open('.overcommit.yml', 'w') { |f| f.write(config) }
       File.open('test.txt', 'w') { |f| f.write(file_contents) }
       `git add test.txt`

--- a/spec/integration/disable_overcommit_spec.rb
+++ b/spec/integration/disable_overcommit_spec.rb
@@ -5,8 +5,7 @@ describe 'disabling Overcommit' do
 
   around do |example|
     repo do
-      Overcommit::Installer.new(Overcommit::Logger.silent).
-                            run('.', action: :install)
+      `overcommit --install > #{File::NULL}`
       Overcommit::Utils.with_environment('OVERCOMMIT_DISABLE' => overcommit_disable) do
         FileUtils.touch 'blah'
         `git add blah`

--- a/spec/integration/resolving_merge_conflict_spec.rb
+++ b/spec/integration/resolving_merge_conflict_spec.rb
@@ -20,8 +20,7 @@ describe 'resolving merge conflicts' do
       `git checkout -q master`
       `git merge branch1`
       `git merge branch2` # Results in merge conflict
-      Overcommit::Installer.new(Overcommit::Logger.silent).
-                            run('.', action: :install)
+      `overcommit --install > #{File::NULL}`
       echo('Conflicts Resolved', 'some-file')
       `git add some-file`
       example.run


### PR DESCRIPTION
Extracted from #185.

This better mirrors the behavior of the cherry pick conflict spec.

See 97a00a7 for a more thorough justification.