### PR TITLE
Restore MERGE_HEAD and CHERRY_PICK_HEAD without newline

### DIFF
--- a/lib/overcommit/git_repo.rb
+++ b/lib/overcommit/git_repo.rb
@@ -167,7 +167,7 @@ module Overcommit
         FileUtils.touch(File.expand_path('MERGE_MODE', Overcommit::Utils.git_dir))
 
         File.open(File.expand_path('MERGE_HEAD', Overcommit::Utils.git_dir), 'w') do |f|
-          f.write("#{@merge_head}\n")
+          f.write(@merge_head)
         end
         @merge_head = nil
       end
@@ -186,7 +186,7 @@ module Overcommit
       if @cherry_head
         File.open(File.expand_path('CHERRY_PICK_HEAD',
                                    Overcommit::Utils.git_dir), 'w') do |f|
-          f.write("#{@cherry_head}\n")
+          f.write(@cherry_head)
         end
         @cherry_head = nil
       end


### PR DESCRIPTION
Extracted from #185.

Including the trailing newline results in an error on Windows:
```
fatal: Corrupt MERGE_HEAD file (<commit-hash>)
```