### PR TITLE
Add pre-commit hook for Scalariform

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -351,6 +351,13 @@ PreCommit:
       - '**/*.gemspec'
       - '**/*.rb'
 
+  Scalariform:
+    enabled: false
+    description: 'Checking formatting with Scalariform'
+    required_executable: 'scalariform'
+    flags: ['--test']
+    include: '**/*.scala'
+
   Scalastyle:
     enabled: false
     description: 'Analyzing with Scalastyle'

--- a/lib/overcommit/hook/pre_commit/base.rb
+++ b/lib/overcommit/hook/pre_commit/base.rb
@@ -32,7 +32,7 @@ module Overcommit::Hook::PreCommit
         end
 
         file = extract_file(match, message)
-        line = extract_line(match, message) unless match[:line].nil?
+        line = extract_line(match, message) if match.names.include?('line') && match[:line]
         type = extract_type(match, message, type_categorizer)
 
         Overcommit::Hook::Message.new(type, file, line, message)

--- a/lib/overcommit/hook/pre_commit/scalariform.rb
+++ b/lib/overcommit/hook/pre_commit/scalariform.rb
@@ -1,0 +1,18 @@
+module Overcommit::Hook::PreCommit
+  # Runs `scalariform` against any modified Scala files.
+  class Scalariform < Base
+    MESSAGE_REGEX = /^\[(?<type>FAILED|ERROR)\]\s+(?<file>.+)/
+
+    def run
+      result = execute(command + applicable_files)
+
+      # example message:
+      #   [FAILED] path/to/file.scala
+      extract_messages(
+        result.stdout.split("\n").grep(MESSAGE_REGEX),
+        MESSAGE_REGEX,
+        lambda { |type| type == 'ERROR' ? :error : :warning }
+      )
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_commit/scalariform_spec.rb
+++ b/spec/overcommit/hook/pre_commit/scalariform_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::Scalariform do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  before do
+    subject.stub(:applicable_files).and_return(%w[file1.scala file2.scala])
+  end
+
+  context 'when there were no failures or errors' do
+    let(:result) { double('result') }
+
+    before do
+      subject.stub(:execute).and_return(result)
+      result.stub(:stdout).and_return([
+        'Assuming source is Scala 2.10.4',
+        'Formatting with default preferences.',
+        '[OK]     file1.scala',
+        '[OK]     file2.scala'
+      ].join("\n"))
+    end
+
+    it { should pass }
+  end
+
+  context 'when there were failures' do
+    let(:result) { double('result') }
+
+    before do
+      subject.stub(:execute).and_return(result)
+      result.stub(:stdout).and_return([
+        'Assuming source is Scala 2.10.4',
+        'Formatting with default preferences.',
+        '[OK]     file1.scala',
+        '[FAILED] file2.scala'
+      ].join("\n"))
+    end
+
+    it { should warn }
+  end
+
+  context 'when there were errors' do
+    let(:result) { double('result') }
+
+    before do
+      subject.stub(:execute).and_return(result)
+      result.stub(:stdout).and_return([
+        'Assuming source is Scala 2.10.4',
+        'Formatting with default preferences.',
+        '[ERROR]  file1.scala',
+        '[OK]     file2.scala'
+      ].join("\n"))
+    end
+
+    it { should fail_hook }
+  end
+end


### PR DESCRIPTION
Scalariform output does not include line numbers, so this PR also includes a change to allow the message regex to omit the `line` group.

Closes #192