### PR TITLE
Include *.svg for XML checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## master (unreleased)
 
-* Add `**/*.svg` to `ImageOptim` default includes configuration
+* Add `**/*.svg` to `ImageOptim`, `XmlLint`, and `XmlSyntax` default includes
+  configuration
 * Make `IndexTags` hooks quiet by default
 * Add `Vint` pre-commit hook that checks Vim script with
   [Vint](https://github.com/Kuniwak/vint)

--- a/config/default.yml
+++ b/config/default.yml
@@ -438,13 +438,17 @@ PreCommit:
     description: 'Analyzing with xmllint'
     required_executable: 'xmllint'
     flags: ['--noout']
-    include: '**/*.xml'
+    include:
+      - '**/*.xml'
+      - '**/*.svg'
 
   XmlSyntax:
     enabled: false
     description: 'Checking XML syntax'
     required_library: 'rexml/document'
-    include: '**/*.xml'
+    include:
+      - '**/*.xml'
+      - '**/*.svg'
 
   YamlSyntax:
     enabled: false


### PR DESCRIPTION
SVG is an XML-based vector image format. It seems like we should be
running the XML checks on these files.