### PR TITLE
Update regex to filter out detached HEAD for Git 2.4.0

### DIFF
--- a/lib/overcommit/git_repo.rb
+++ b/lib/overcommit/git_repo.rb
@@ -255,7 +255,7 @@ module Overcommit
     # @return [Array<String>] list of branches containing the given commit
     def branches_containing_commit(commit_ref)
       `git branch --column=dense --contains #{commit_ref}`.
-        sub(/\(detached from .*?\)/, ''). # ignore detached HEAD
+        sub(/\((HEAD )?detached (from|at) .*?\)/, ''). # ignore detached HEAD
         split(/\s+/).
         reject { |s| s.empty? || s == '*' }
     end


### PR DESCRIPTION
Fixes #203