### PR TITLE
Set diff.submodule to short for staged submodule test cases

### DIFF
--- a/spec/overcommit/hook_context/pre_commit_spec.rb
+++ b/spec/overcommit/hook_context/pre_commit_spec.rb
@@ -191,6 +191,7 @@ describe Overcommit::HookContext::PreCommit do
       end
 
       it 'keeps staged submodule change' do
+        `git config diff.submodule short`
         expect { subject }.to_not change {
           (`git diff --cached` =~ /-Subproject commit[\s\S]*\+Subproject commit/).nil?
         }.from(false)
@@ -341,6 +342,7 @@ describe Overcommit::HookContext::PreCommit do
       end
 
       it 'keeps staged submodule change' do
+        `git config diff.submodule short`
         expect { subject }.to_not change {
           (`git diff --cached` =~ /-Subproject commit[\s\S]*\+Subproject commit/).nil?
         }.from(false)
@@ -366,6 +368,7 @@ describe Overcommit::HookContext::PreCommit do
       end
 
       it 'keeps staged submodule change' do
+        `git config diff.submodule short`
         expect { subject }.to_not change {
           (`git diff --cached` =~ /-Subproject commit[\s\S]*\+Subproject commit/).nil?
         }.from(false)


### PR DESCRIPTION
Without this change, these tests will fail if the user has diff.submodule set to 'log' globally.

Fixes #204