### PR TITLE
Add EmptyMessage commit-msg hook

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -26,6 +26,10 @@ CommitMsg:
     enabled: true
     description: 'Checking subject capitalization'
 
+  EmptyMessage:
+    enabled: true
+    description: 'Checking for empty commit message'
+
   GerritChangeId:
     enabled: false
     description: 'Ensuring Gerrit Change-Id is present'

--- a/config/default.yml
+++ b/config/default.yml
@@ -29,6 +29,7 @@ CommitMsg:
   EmptyMessage:
     enabled: true
     description: 'Checking for empty commit message'
+    quiet: true
 
   GerritChangeId:
     enabled: false

--- a/lib/overcommit/hook/commit_msg/empty_message.rb
+++ b/lib/overcommit/hook/commit_msg/empty_message.rb
@@ -1,0 +1,10 @@
+module Overcommit::Hook::CommitMsg
+  # Checks that the commit message is not empty
+  class EmptyMessage < Base
+    def run
+      return :pass unless empty_message?
+
+      [:fail, 'Commit message should not be empty']
+    end
+  end
+end

--- a/spec/overcommit/hook/commit_msg/empty_message_spec.rb
+++ b/spec/overcommit/hook/commit_msg/empty_message_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::CommitMsg::EmptyMessage do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  before do
+    subject.stub(:empty_message?).and_return(commit_msg.strip.empty?)
+  end
+
+  context 'when commit message is empty' do
+    let(:commit_msg) { '' }
+
+    it { should fail_hook }
+  end
+
+  context 'when commit message contains only whitespace' do
+    let(:commit_msg) { ' ' }
+
+    it { should fail_hook }
+  end
+
+  context 'when commit message is not empty' do
+    let(:commit_msg) { 'Some commit message' }
+
+    it { should pass }
+  end
+end


### PR DESCRIPTION
This hook will fail if the commit message is empty or contains only whitespace. Enabled by default, as I suspect this is something most users would never do intentionally.

Refs #201