### PR TITLE
Fix parsing of reek output for newer versions of reek

### DIFF
--- a/lib/overcommit/hook/pre_commit/reek.rb
+++ b/lib/overcommit/hook/pre_commit/reek.rb
@@ -11,7 +11,7 @@ module Overcommit::Hook::PreCommit
 
       extract_messages(
         output,
-        /^(?<file>[^:]+):(?<line>\d+):/,
+        /^\s*(?<file>[^:]+):(?<line>\d+):/,
       )
     end
 

--- a/spec/overcommit/hook/pre_commit/reek_spec.rb
+++ b/spec/overcommit/hook/pre_commit/reek_spec.rb
@@ -28,15 +28,35 @@ describe Overcommit::Hook::PreCommit::Reek do
     end
 
     context 'and it reports warnings' do
-      before do
-        result.stub(:stdout).and_return([
-          'file1.rb -- 1 warning:',
-          'file1.rb:1: MyClass#my_method performs a nil-check. (NilCheck)'
-        ].join("\n"))
-        result.stub(:stderr).and_return('')
+      context 'in old format' do
+        before do
+          result.stub(:stdout).and_return([
+            'file1.rb -- 1 warning:',
+            'file1.rb:1: MyClass#my_method performs a nil-check. (NilCheck)'
+          ].join("\n"))
+          result.stub(:stderr).and_return('')
+        end
+
+        it { should fail_hook }
+        it 'parses the right file' do
+          subject.run.map(&:file).should == ['file1.rb']
+        end
       end
 
-      it { should fail_hook }
+      context 'in new format' do
+        before do
+          result.stub(:stdout).and_return([
+            'file1.rb -- 1 warning:',
+            '  file1.rb:1: MyClass#my_method performs a nil-check. (NilCheck)'
+          ].join("\n"))
+          result.stub(:stderr).and_return('')
+        end
+
+        it { should fail_hook }
+        it 'parses the right file' do
+          subject.run.map(&:file).should == ['file1.rb']
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Looks like possibly on newer versions of reek (or it never worked to begin with), the output has an indent the original regex didn't account for. Now it does, also added some additional specs to cover this filename parsing.