### PR TITLE
Stub methods of hook context rather than the hook itself

### DIFF
--- a/spec/overcommit/hook/commit_msg/capitalized_subject_spec.rb
+++ b/spec/overcommit/hook/commit_msg/capitalized_subject_spec.rb
@@ -7,8 +7,8 @@ describe Overcommit::Hook::CommitMsg::CapitalizedSubject do
   subject { described_class.new(config, context) }
 
   before do
-    subject.stub(:commit_message_lines).and_return(commit_msg.split("\n"))
-    subject.stub(:empty_message?).and_return(commit_msg.empty?)
+    context.stub(:commit_message_lines).and_return(commit_msg.split("\n"))
+    context.stub(:empty_message?).and_return(commit_msg.empty?)
   end
 
   context 'when commit message is empty' do

--- a/spec/overcommit/hook/commit_msg/empty_message_spec.rb
+++ b/spec/overcommit/hook/commit_msg/empty_message_spec.rb
@@ -6,7 +6,7 @@ describe Overcommit::Hook::CommitMsg::EmptyMessage do
   subject { described_class.new(config, context) }
 
   before do
-    subject.stub(:empty_message?).and_return(commit_msg.strip.empty?)
+    context.stub(:empty_message?).and_return(commit_msg.strip.empty?)
   end
 
   context 'when commit message is empty' do

--- a/spec/overcommit/hook/commit_msg/gerrit_change_id_spec.rb
+++ b/spec/overcommit/hook/commit_msg/gerrit_change_id_spec.rb
@@ -9,7 +9,7 @@ describe Overcommit::Hook::CommitMsg::GerritChangeId do
   before do
     commit_msg_file.write(commit_msg)
     commit_msg_file.close
-    subject.stub(:commit_message_file).and_return(commit_msg_file.path)
+    context.stub(:commit_message_file).and_return(commit_msg_file.path)
   end
 
   context 'when the commit message contains no Change-Id' do

--- a/spec/overcommit/hook/commit_msg/hard_tabs_spec.rb
+++ b/spec/overcommit/hook/commit_msg/hard_tabs_spec.rb
@@ -6,8 +6,8 @@ describe Overcommit::Hook::CommitMsg::HardTabs do
   subject { described_class.new(config, context) }
 
   before do
-    subject.stub(:commit_message).and_return(commit_msg)
-    subject.stub(:empty_message?).and_return(commit_msg.empty?)
+    context.stub(:commit_message).and_return(commit_msg)
+    context.stub(:empty_message?).and_return(commit_msg.empty?)
   end
 
   context 'when commit message is empty' do

--- a/spec/overcommit/hook/commit_msg/russian_novel_spec.rb
+++ b/spec/overcommit/hook/commit_msg/russian_novel_spec.rb
@@ -6,7 +6,7 @@ describe Overcommit::Hook::CommitMsg::RussianNovel do
   subject { described_class.new(config, context) }
 
   before do
-    subject.stub(:commit_message_lines).and_return(commit_msg)
+    context.stub(:commit_message_lines).and_return(commit_msg)
   end
 
   context 'when message contains fewer than 30 lines' do

--- a/spec/overcommit/hook/commit_msg/single_line_subject_spec.rb
+++ b/spec/overcommit/hook/commit_msg/single_line_subject_spec.rb
@@ -6,8 +6,8 @@ describe Overcommit::Hook::CommitMsg::SingleLineSubject do
   subject { described_class.new(config, context) }
 
   before do
-    subject.stub(:commit_message_lines).and_return(commit_msg.split("\n"))
-    subject.stub(:empty_message?).and_return(commit_msg.empty?)
+    context.stub(:commit_message_lines).and_return(commit_msg.split("\n"))
+    context.stub(:empty_message?).and_return(commit_msg.empty?)
   end
 
   context 'when commit message is empty' do

--- a/spec/overcommit/hook/commit_msg/text_width_spec.rb
+++ b/spec/overcommit/hook/commit_msg/text_width_spec.rb
@@ -6,8 +6,8 @@ describe Overcommit::Hook::CommitMsg::TextWidth do
   subject { described_class.new(config, context) }
 
   before do
-    subject.stub(:commit_message_lines).and_return(commit_msg.split("\n"))
-    subject.stub(:empty_message?).and_return(commit_msg.empty?)
+    context.stub(:commit_message_lines).and_return(commit_msg.split("\n"))
+    context.stub(:empty_message?).and_return(commit_msg.empty?)
   end
 
   context 'when commit message is empty' do

--- a/spec/overcommit/hook/commit_msg/trailing_period_spec.rb
+++ b/spec/overcommit/hook/commit_msg/trailing_period_spec.rb
@@ -6,8 +6,8 @@ describe Overcommit::Hook::CommitMsg::TrailingPeriod do
   subject { described_class.new(config, context) }
 
   before do
-    subject.stub(:commit_message_lines).and_return(commit_msg.split("\n"))
-    subject.stub(:empty_message?).and_return(commit_msg.empty?)
+    context.stub(:commit_message_lines).and_return(commit_msg.split("\n"))
+    context.stub(:empty_message?).and_return(commit_msg.empty?)
   end
 
   context 'when commit message is empty' do

--- a/spec/overcommit/hook/post_commit/git_guilt_spec.rb
+++ b/spec/overcommit/hook/post_commit/git_guilt_spec.rb
@@ -42,7 +42,7 @@ describe Overcommit::Hook::PostCommit::GitGuilt do
 
   context 'when there is no previous commit' do
     before do
-      subject.stub(:initial_commit?).and_return(true)
+      context.stub(:initial_commit?).and_return(true)
     end
 
     it { should pass }

--- a/spec/overcommit/hook/pre_push/protected_branches_spec.rb
+++ b/spec/overcommit/hook/pre_push/protected_branches_spec.rb
@@ -11,7 +11,7 @@ describe Overcommit::Hook::PrePush::ProtectedBranches do
 
   before do
     subject.stub(:branches).and_return([protected_branch])
-    subject.stub(:pushed_refs).and_return([pushed_ref])
+    context.stub(:pushed_refs).and_return([pushed_ref])
   end
 
   context 'when pushing to unprotected branch' do

--- a/spec/overcommit/hook/pre_rebase/merged_commits_spec.rb
+++ b/spec/overcommit/hook/pre_rebase/merged_commits_spec.rb
@@ -13,7 +13,7 @@ describe Overcommit::Hook::PreRebase::MergedCommits do
 
   context 'when rebasing a detached HEAD' do
     before do
-      subject.stub(:detached_head?) { true }
+      context.stub(:detached_head?) { true }
     end
 
     it { should pass }
@@ -21,8 +21,8 @@ describe Overcommit::Hook::PreRebase::MergedCommits do
 
   context 'when there are no commits to rebase' do
     before do
-      subject.stub(:detached_head?) { false }
-      subject.stub(:rebased_commits) { [] }
+      context.stub(:detached_head?) { false }
+      context.stub(:rebased_commits) { [] }
     end
 
     it { should pass }
@@ -33,8 +33,8 @@ describe Overcommit::Hook::PreRebase::MergedCommits do
     let(:rebased_branch) { 'topic' }
 
     before do
-      subject.stub(:detached_head?) { false }
-      subject.stub(:rebased_commits) { [commit_sha1] }
+      context.stub(:detached_head?) { false }
+      context.stub(:rebased_commits) { [commit_sha1] }
     end
 
     context 'when commits have not yet been merged' do


### PR DESCRIPTION
This will prevent bugs like #216 from cropping up again.

The specs will fail until #217 is merged.