### PR TITLE
CaseConflicts: Only check against existing files if not initial commit

### DIFF
--- a/lib/overcommit/hook/pre_commit/case_conflicts.rb
+++ b/lib/overcommit/hook/pre_commit/case_conflicts.rb
@@ -3,8 +3,13 @@ module Overcommit::Hook::PreCommit
   # Adapted from https://github.com/pre-commit/pre-commit-hooks
   class CaseConflicts < Base
     def run
-      paths = Set.new(applicable_files.map { |file| File.dirname(file) + File::SEPARATOR })
-      repo_files = Set.new(Overcommit::GitRepo.list_files(paths.to_a) + applicable_files)
+      repo_files = Set.new(applicable_files)
+
+      unless Overcommit::GitRepo.initial_commit?
+        paths = repo_files.map { |file| File.dirname(file) + File::SEPARATOR }
+        repo_files += Overcommit::GitRepo.list_files(paths)
+      end
+
       conflict_hash = repo_files.classify(&:downcase).
         select { |_, files| files.size > 1 }
       conflict_files = applicable_files.

--- a/spec/overcommit/hook/pre_commit/case_conflicts_spec.rb
+++ b/spec/overcommit/hook/pre_commit/case_conflicts_spec.rb
@@ -6,6 +6,7 @@ describe Overcommit::Hook::PreCommit::CaseConflicts do
   subject { described_class.new(config, context) }
 
   before do
+    Overcommit::GitRepo.stub(:initial_commit?).and_return(false)
     Overcommit::GitRepo.stub(:list_files).and_return(%w[foo])
   end
 


### PR DESCRIPTION
Otherwise you get `fatal: Not a valid object name HEAD` since `git ls-tree` requires an existing rev.

This PR also exposes `HookContext::PreCommit#initial_commit?` as a public method with a corresponding delegator to make it accessible to hooks.