### PR TITLE
Fix and update (semi)standard hooks

### DIFF
--- a/lib/overcommit/hook/pre_commit/semi_standard.rb
+++ b/lib/overcommit/hook/pre_commit/semi_standard.rb
@@ -5,14 +5,14 @@ module Overcommit::Hook::PreCommit
   class SemiStandard < Base
     def run
       result = execute(command + applicable_files)
-      output = result.stderr.chomp
+      output = result.stdout.chomp
       return :pass if result.success? && output.empty?
 
       # example message:
       #   path/to/file.js:1:1: Error message (ruleName)
       extract_messages(
         output.split("\n")[1..-1], # ignore header line
-        /^(?<file>[^:]+):(?<line>\d+)/
+        /^\s*(?<file>[^:]+):(?<line>\d+)/
       )
     end
   end

--- a/lib/overcommit/hook/pre_commit/standard.rb
+++ b/lib/overcommit/hook/pre_commit/standard.rb
@@ -5,14 +5,14 @@ module Overcommit::Hook::PreCommit
   class Standard < Base
     def run
       result = execute(command + applicable_files)
-      output = result.stderr.chomp
+      output = result.stdout.chomp
       return :pass if result.success? && output.empty?
 
       # example message:
       #   path/to/file.js:1:1: Error message (ruleName)
       extract_messages(
         output.split("\n")[1..-1], # ignore header line
-        /^(?<file>[^:]+):(?<line>\d+)/
+        /^\s*(?<file>[^:]+):(?<line>\d+)/
       )
     end
   end

--- a/spec/overcommit/hook/pre_commit/semi_standard_spec.rb
+++ b/spec/overcommit/hook/pre_commit/semi_standard_spec.rb
@@ -12,7 +12,7 @@ describe Overcommit::Hook::PreCommit::SemiStandard do
   context 'when semistandard exits successfully' do
     before do
       result = double('result')
-      result.stub(success?: true, stderr: '')
+      result.stub(success?: true, stdout: '')
       subject.stub(:execute).and_return(result)
     end
 
@@ -29,9 +29,9 @@ describe Overcommit::Hook::PreCommit::SemiStandard do
 
     context 'and it reports an error' do
       before do
-        result.stub(:stderr).and_return([
-          'Error: Code style check failed:',
-          'file1.js:1:1: Extra semicolon. (eslint/semi)'
+        result.stub(:stdout).and_return([
+          'semistandard: Use Semicolons For All! (https://github.com/Flet/semistandard)',
+          '  file1.js:1:1: Extra semicolon. (eslint/semi)'
         ].join("\n"))
       end
 

--- a/spec/overcommit/hook/pre_commit/standard_spec.rb
+++ b/spec/overcommit/hook/pre_commit/standard_spec.rb
@@ -12,7 +12,7 @@ describe Overcommit::Hook::PreCommit::Standard do
   context 'when standard exits successfully' do
     before do
       result = double('result')
-      result.stub(success?: true, stderr: '')
+      result.stub(success?: true, stdout: '')
       subject.stub(:execute).and_return(result)
     end
 
@@ -29,9 +29,9 @@ describe Overcommit::Hook::PreCommit::Standard do
 
     context 'and it reports an error' do
       before do
-        result.stub(:stderr).and_return([
-          'Error: Use JavaScript Standard Style (https://github.com/feross/standard)',
-          'file1.js:1:1: Extra semicolon. (eslint/semi)'
+        result.stub(:stdout).and_return([
+          'standard: Use JavaScript Standard Style (https://github.com/feross/standard)',
+          '  file1.js:1:1: Extra semicolon. (eslint/semi)'
         ].join("\n"))
       end
 


### PR DESCRIPTION
* Use stdout instead of stderr
* Update regexp to account for space before file path in output
* Update tests to mimic latest tool output

See brigade/overcommit#231