### PR TITLE
Add HookContext::PostRewrite#rewritten_commits

### DIFF
--- a/lib/overcommit/hook_context/post_rewrite.rb
+++ b/lib/overcommit/hook_context/post_rewrite.rb
@@ -14,5 +14,18 @@ module Overcommit::HookContext
     def rebase?
       @args[0] == 'rebase'
     end
+
+    # Returns the list of commits rewritten by the action that triggered this
+    # hook run.
+    #
+    # @return [Array<RewrittenCommit>]
+    def rewritten_commits
+      @rewritten_commits ||= input_lines.map do |line|
+        RewrittenCommit.new(*line.split(' '))
+      end
+    end
+
+    # Struct encapsulating the old and new sha1 hashes of a rewritten commit
+    RewrittenCommit = Struct.new(:old_sha1, :new_sha1)
   end
 end

--- a/spec/overcommit/hook_context/post_rewrite_spec.rb
+++ b/spec/overcommit/hook_context/post_rewrite_spec.rb
@@ -37,4 +37,46 @@ describe Overcommit::HookContext::PostRewrite do
       it { should == true }
     end
   end
+
+  describe '#rewritten_commits' do
+    subject(:rewritten_commits) { context.rewritten_commits }
+
+    let(:old_sha1_1) { random_hash }
+    let(:new_sha1_1) { random_hash }
+    let(:old_sha1_2) { random_hash }
+    let(:new_sha1_2) { random_hash }
+
+    context 'when rewrite was triggered by amend' do
+      let(:args) { ['amend'] }
+
+      before do
+        input.stub(:read).and_return("#{old_sha1_1} #{new_sha1_1}\n")
+      end
+
+      it 'should parse rewritten commit info from the input' do
+        rewritten_commits.length.should == 1
+        rewritten_commits[0].old_sha1.should == old_sha1_1
+        rewritten_commits[0].new_sha1.should == new_sha1_1
+      end
+    end
+
+    context 'when rewrite was triggered by rebase' do
+      let(:args) { ['rebase'] }
+
+      before do
+        input.stub(:read).and_return([
+          "#{old_sha1_1} #{new_sha1_1}",
+          "#{old_sha1_2} #{new_sha1_2}"
+        ].join("\n"))
+      end
+
+      it 'should parse rewritten commit info from the input' do
+        rewritten_commits.length.should == 2
+        rewritten_commits[0].old_sha1.should == old_sha1_1
+        rewritten_commits[0].new_sha1.should == new_sha1_1
+        rewritten_commits[1].old_sha1.should == old_sha1_2
+        rewritten_commits[1].new_sha1.should == new_sha1_2
+      end
+    end
+  end
 end


### PR DESCRIPTION
Returns the list of commits rewritten by the amendment or rebase that triggered the hook run.

From the [githooks documentation](https://www.kernel.org/pub/software/scm/git/docs/githooks.html):

> The hook receives a list of the rewritten commits on stdin, in the format

>  `<old-sha1> SP <new-sha1> [ SP <extra-info> ] LF`

> The `extra-info` is again command-dependent. If it is empty, the preceding `SP` is also omitted. Currently, no commands pass any `extra-info`.