### PR TITLE
Sort `applicable_files` in lexicographical order

### DIFF
--- a/lib/overcommit/hook/base.rb
+++ b/lib/overcommit/hook/base.rb
@@ -147,7 +147,7 @@ module Overcommit::Hook
     # Gets a list of staged files that apply to this hook based on its
     # configured `include` and `exclude` lists.
     def applicable_files
-      @applicable_files ||= modified_files.select { |file| applicable_file?(file) }
+      @applicable_files ||= modified_files.select { |file| applicable_file?(file) }.sort
     end
 
     private


### PR DESCRIPTION
`PreCommit` and `PostRewrite` hooks may aggregate changes from more than one commit, so `modified_files` is not guaranteed to be sorted already.