### PR TITLE
Add NpmInstall post-checkout, post-commit, post-merge, and post-rewrite hooks

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -527,6 +527,16 @@ PostCheckout:
     quiet: true
     required_executable: 'ctags'
 
+  NpmInstall:
+    enabled: false
+    description: 'Installing NPM dependencies'
+    requires_files: true
+    required_executable: 'npm'
+    flags: ['install']
+    include:
+      - 'package.json'
+      - 'npm-shrinkwrap.json'
+
   SubmoduleStatus:
     enabled: false
     description: 'Checking submodule status'
@@ -554,6 +564,16 @@ PostCommit:
     quiet: true
     required_executable: 'ctags'
 
+  NpmInstall:
+    enabled: false
+    description: 'Installing NPM dependencies'
+    requires_files: true
+    required_executable: 'npm'
+    flags: ['install']
+    include:
+      - 'package.json'
+      - 'npm-shrinkwrap.json'
+
   SubmoduleStatus:
     enabled: false
     description: 'Checking submodule status'
@@ -572,6 +592,16 @@ PostMerge:
     quiet: true
     required_executable: 'ctags'
 
+  NpmInstall:
+    enabled: false
+    description: 'Installing NPM dependencies'
+    requires_files: true
+    required_executable: 'npm'
+    flags: ['install']
+    include:
+      - 'package.json'
+      - 'npm-shrinkwrap.json'
+
   SubmoduleStatus:
     enabled: false
     description: 'Checking submodule status'
@@ -589,6 +619,16 @@ PostRewrite:
     description: 'Generating tags file from source'
     quiet: true
     required_executable: 'ctags'
+
+  NpmInstall:
+    enabled: false
+    description: 'Installing NPM dependencies'
+    requires_files: true
+    required_executable: 'npm'
+    flags: ['install']
+    include:
+      - 'package.json'
+      - 'npm-shrinkwrap.json'
 
   SubmoduleStatus:
     enabled: false

--- a/lib/overcommit/hook/post_checkout/npm_install.rb
+++ b/lib/overcommit/hook/post_checkout/npm_install.rb
@@ -1,0 +1,11 @@
+require 'overcommit/hook/shared/npm_install'
+
+module Overcommit::Hook::PostCheckout
+  # Runs `npm install` when a change is detected in the repository's
+  # dependencies.
+  #
+  # @see {Overcommit::Hook::Shared::NpmInstall}
+  class NpmInstall < Base
+    include Overcommit::Hook::Shared::NpmInstall
+  end
+end

--- a/lib/overcommit/hook/post_commit/npm_install.rb
+++ b/lib/overcommit/hook/post_commit/npm_install.rb
@@ -1,0 +1,11 @@
+require 'overcommit/hook/shared/npm_install'
+
+module Overcommit::Hook::PostCommit
+  # Runs `npm install` when a change is detected in the repository's
+  # dependencies.
+  #
+  # @see {Overcommit::Hook::Shared::NpmInstall}
+  class NpmInstall < Base
+    include Overcommit::Hook::Shared::NpmInstall
+  end
+end

--- a/lib/overcommit/hook/post_merge/npm_install.rb
+++ b/lib/overcommit/hook/post_merge/npm_install.rb
@@ -1,0 +1,11 @@
+require 'overcommit/hook/shared/npm_install'
+
+module Overcommit::Hook::PostMerge
+  # Runs `npm install` when a change is detected in the repository's
+  # dependencies.
+  #
+  # @see {Overcommit::Hook::Shared::NpmInstall}
+  class NpmInstall < Base
+    include Overcommit::Hook::Shared::NpmInstall
+  end
+end

--- a/lib/overcommit/hook/post_rewrite/npm_install.rb
+++ b/lib/overcommit/hook/post_rewrite/npm_install.rb
@@ -1,0 +1,11 @@
+require 'overcommit/hook/shared/npm_install'
+
+module Overcommit::Hook::PostRewrite
+  # Runs `npm install` when a change is detected in the repository's
+  # dependencies.
+  #
+  # @see {Overcommit::Hook::Shared::NpmInstall}
+  class NpmInstall < Base
+    include Overcommit::Hook::Shared::NpmInstall
+  end
+end

--- a/lib/overcommit/hook/shared/npm_install.rb
+++ b/lib/overcommit/hook/shared/npm_install.rb
@@ -1,0 +1,13 @@
+module Overcommit::Hook::Shared
+  # Shared code used by all NpmInstall hooks. Runs `npm install` when a change
+  # is detected in the repository's dependencies.
+  #
+  # @see https://www.npmjs.com/
+  module NpmInstall
+    def run
+      result = execute(command)
+      return :fail, result.stderr unless result.success?
+      :pass
+    end
+  end
+end

--- a/spec/overcommit/hook/post_checkout/npm_install_spec.rb
+++ b/spec/overcommit/hook/post_checkout/npm_install_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PostCheckout::NpmInstall do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  let(:result) { double('result') }
+
+  before do
+    subject.stub(:execute).and_return(result)
+  end
+
+  context 'when npm install exits successfully' do
+    before do
+      subject.stub(:success?).and_return(true)
+    end
+
+    it { should pass }
+  end
+
+  context 'when npm install exits unsuccessfully' do
+    before do
+      subject.stub(success?: false, stderr: "npm ERR! install Couldn't read dependencies")
+    end
+
+    it { should fail_hook }
+  end
+end

--- a/spec/overcommit/hook/post_checkout/npm_install_spec.rb
+++ b/spec/overcommit/hook/post_checkout/npm_install_spec.rb
@@ -13,7 +13,7 @@ describe Overcommit::Hook::PostCheckout::NpmInstall do
 
   context 'when npm install exits successfully' do
     before do
-      subject.stub(:success?).and_return(true)
+      result.stub(:success?).and_return(true)
     end
 
     it { should pass }
@@ -21,7 +21,7 @@ describe Overcommit::Hook::PostCheckout::NpmInstall do
 
   context 'when npm install exits unsuccessfully' do
     before do
-      subject.stub(success?: false, stderr: "npm ERR! install Couldn't read dependencies")
+      result.stub(success?: false, stderr: "npm ERR! install Couldn't read dependencies")
     end
 
     it { should fail_hook }

--- a/spec/overcommit/hook/post_commit/npm_install_spec.rb
+++ b/spec/overcommit/hook/post_commit/npm_install_spec.rb
@@ -13,7 +13,7 @@ describe Overcommit::Hook::PostCommit::NpmInstall do
 
   context 'when npm install exits successfully' do
     before do
-      subject.stub(:success?).and_return(true)
+      result.stub(:success?).and_return(true)
     end
 
     it { should pass }
@@ -21,7 +21,7 @@ describe Overcommit::Hook::PostCommit::NpmInstall do
 
   context 'when npm install exits unsuccessfully' do
     before do
-      subject.stub(success?: false, stderr: "npm ERR! install Couldn't read dependencies")
+      result.stub(success?: false, stderr: "npm ERR! install Couldn't read dependencies")
     end
 
     it { should fail_hook }

--- a/spec/overcommit/hook/post_commit/npm_install_spec.rb
+++ b/spec/overcommit/hook/post_commit/npm_install_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PostCommit::NpmInstall do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  let(:result) { double('result') }
+
+  before do
+    subject.stub(:execute).and_return(result)
+  end
+
+  context 'when npm install exits successfully' do
+    before do
+      subject.stub(:success?).and_return(true)
+    end
+
+    it { should pass }
+  end
+
+  context 'when npm install exits unsuccessfully' do
+    before do
+      subject.stub(success?: false, stderr: "npm ERR! install Couldn't read dependencies")
+    end
+
+    it { should fail_hook }
+  end
+end

--- a/spec/overcommit/hook/post_merge/npm_install_spec.rb
+++ b/spec/overcommit/hook/post_merge/npm_install_spec.rb
@@ -13,7 +13,7 @@ describe Overcommit::Hook::PostMerge::NpmInstall do
 
   context 'when npm install exits successfully' do
     before do
-      subject.stub(:success?).and_return(true)
+      result.stub(:success?).and_return(true)
     end
 
     it { should pass }
@@ -21,7 +21,7 @@ describe Overcommit::Hook::PostMerge::NpmInstall do
 
   context 'when npm install exits unsuccessfully' do
     before do
-      subject.stub(success?: false, stderr: "npm ERR! install Couldn't read dependencies")
+      result.stub(success?: false, stderr: "npm ERR! install Couldn't read dependencies")
     end
 
     it { should fail_hook }

--- a/spec/overcommit/hook/post_merge/npm_install_spec.rb
+++ b/spec/overcommit/hook/post_merge/npm_install_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PostMerge::NpmInstall do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  let(:result) { double('result') }
+
+  before do
+    subject.stub(:execute).and_return(result)
+  end
+
+  context 'when npm install exits successfully' do
+    before do
+      subject.stub(:success?).and_return(true)
+    end
+
+    it { should pass }
+  end
+
+  context 'when npm install exits unsuccessfully' do
+    before do
+      subject.stub(success?: false, stderr: "npm ERR! install Couldn't read dependencies")
+    end
+
+    it { should fail_hook }
+  end
+end

--- a/spec/overcommit/hook/post_rewrite/npm_install_spec.rb
+++ b/spec/overcommit/hook/post_rewrite/npm_install_spec.rb
@@ -13,7 +13,7 @@ describe Overcommit::Hook::PostRewrite::NpmInstall do
 
   context 'when npm install exits successfully' do
     before do
-      subject.stub(:success?).and_return(true)
+      result.stub(:success?).and_return(true)
     end
 
     it { should pass }
@@ -21,7 +21,7 @@ describe Overcommit::Hook::PostRewrite::NpmInstall do
 
   context 'when npm install exits unsuccessfully' do
     before do
-      subject.stub(success?: false, stderr: "npm ERR! install Couldn't read dependencies")
+      result.stub(success?: false, stderr: "npm ERR! install Couldn't read dependencies")
     end
 
     it { should fail_hook }

--- a/spec/overcommit/hook/post_rewrite/npm_install_spec.rb
+++ b/spec/overcommit/hook/post_rewrite/npm_install_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PostRewrite::NpmInstall do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  let(:result) { double('result') }
+
+  before do
+    subject.stub(:execute).and_return(result)
+  end
+
+  context 'when npm install exits successfully' do
+    before do
+      subject.stub(:success?).and_return(true)
+    end
+
+    it { should pass }
+  end
+
+  context 'when npm install exits unsuccessfully' do
+    before do
+      subject.stub(success?: false, stderr: "npm ERR! install Couldn't read dependencies")
+    end
+
+    it { should fail_hook }
+  end
+end


### PR DESCRIPTION
Planning on adding similar hooks for package managers like `bundler` and `bower`. Might be worthwhile to add a base `InstallDependencies` module since the code will be pretty much identical.