### PR TITLE
Remove w3c_validators dependency

### DIFF
--- a/overcommit.gemspec
+++ b/overcommit.gemspec
@@ -31,5 +31,4 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'travis', '~> 1.7'
-  s.add_development_dependency 'w3c_validators', '~> 1.2'
 end

--- a/spec/overcommit/hook/pre_commit/w3c_css_spec.rb
+++ b/spec/overcommit/hook/pre_commit/w3c_css_spec.rb
@@ -1,13 +1,16 @@
 require 'spec_helper'
-require 'w3c_validators'
 
 describe Overcommit::Hook::PreCommit::W3cCss do
   let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
   let(:context) { double('context') }
   subject { described_class.new(config, context) }
 
+  let(:fake_exception) { Class.new(StandardError) }
+
   before do
     subject.stub(:applicable_files).and_return(%w[file1.css file2.css])
+    stub_const('W3CValidators::ValidatorUnavailable', fake_exception)
+    stub_const('W3CValidators::ParsingError', fake_exception)
   end
 
   context 'when w3c_validators exits with an exception' do

--- a/spec/overcommit/hook/pre_commit/w3c_html_spec.rb
+++ b/spec/overcommit/hook/pre_commit/w3c_html_spec.rb
@@ -1,13 +1,16 @@
 require 'spec_helper'
-require 'w3c_validators'
 
 describe Overcommit::Hook::PreCommit::W3cHtml do
   let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
   let(:context) { double('context') }
   subject { described_class.new(config, context) }
 
+  let(:fake_exception) { Class.new(StandardError) }
+
   before do
     subject.stub(:applicable_files).and_return(%w[file1.html file2.html])
+    stub_const('W3CValidators::ValidatorUnavailable', fake_exception)
+    stub_const('W3CValidators::ParsingError', fake_exception)
   end
 
   context 'when w3c_validators exits with an exception' do


### PR DESCRIPTION
This was only used in the specs for `W3cCss` and `W3cHtml`, and only to raise library-specific exceptions. Use mock exceptions instead and remove the dependency.