### PR TITLE
Split file args for RuboCop hook

### DIFF
--- a/lib/overcommit/hook/pre_commit/rubo_cop.rb
+++ b/lib/overcommit/hook/pre_commit/rubo_cop.rb
@@ -8,7 +8,7 @@ module Overcommit::Hook::PreCommit
     end
 
     def run
-      result = execute(command + applicable_files)
+      result = execute(command, args: applicable_files)
       return :pass if result.success?
 
       extract_messages(


### PR DESCRIPTION
Should probably do this for all hooks, but this will at least allow `overcommit --run` to run accurately in Appveyor builds.