### PR TITLE
Include template hook in RuboCop check

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -8,6 +8,11 @@ PreCommit:
   RuboCop:
     enabled: true
     command: ['bundle', 'exec', 'rubocop']
+    include:
+      - '**/*.gemspec'
+      - '**/*.rb'
+      - '**/Gemfile'
+      - template-dir/hooks/overcommit-hook
 
   TravisLint:
     enabled: true

--- a/template-dir/hooks/overcommit-hook
+++ b/template-dir/hooks/overcommit-hook
@@ -27,10 +27,12 @@ end
 
 # Check if Overcommit should invoke a Bundler context for loading gems
 require 'yaml'
+# rubocop:disable Style/RescueModifier
 if gemfile = YAML.load_file('.overcommit.yml')['gemfile'] rescue nil
   ENV['BUNDLE_GEMFILE'] = gemfile
   require 'bundler/setup'
 end
+# rubocop:enable Style/RescueModifier
 
 begin
   require 'overcommit'


### PR DESCRIPTION
The hooks in `template-dir` were previously not being included in the `RuboCop` check.