### PR TITLE
Use csv formatter for coffeelint

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -176,8 +176,7 @@ PreCommit:
     enabled: false
     description: 'Analyzing with coffeelint'
     required_executable: 'coffeelint'
-    required_library: 'json'
-    flags: ['--reporter=raw']
+    flags: ['--reporter=csv']
     install_command: 'npm install -g coffeelint'
     include: '**/*.coffee'
 

--- a/lib/overcommit/hook/pre_commit/coffee_lint.rb
+++ b/lib/overcommit/hook/pre_commit/coffee_lint.rb
@@ -3,38 +3,30 @@ module Overcommit::Hook::PreCommit
   #
   # @see http://www.coffeelint.org/
   class CoffeeLint < Base
+    MESSAGE_REGEX = /
+      ^(?<file>.+)
+      ,(?<line>\d*),\d*
+      ,(?<type>\w+)
+      ,(?<msg>.+)$
+    /x
+
+    MESSAGE_TYPE_CATEGORIZER = lambda do |type|
+      type.include?('w') ? :warning : :error
+    end
+
     def run
       result = execute(command + applicable_files)
-
-      begin
-        parse_json_messages(result.stdout)
-      rescue JSON::ParserError => e
-        [:fail, "Error parsing coffeelint output: #{e.message}"]
-      end
+      parse_messages(result.stdout)
     end
 
     private
 
-    def parse_json_messages(output)
-      JSON.parse(output).collect do |file, messages|
-        messages.collect { |msg| extract_message(file, msg) }
-      end.flatten
-    end
-
-    def extract_message(file, message_hash)
-      type = message_hash['level'].include?('w') ? :warning : :error
-      line = message_hash['lineNumber']
-      rule = message_hash['rule']
-      msg = message_hash['message']
-      text =
-        if rule == 'coffeescript_error'
-          # Syntax errors are output in different format.
-          # Splice in the file name and grab the first line.
-          msg.sub('[stdin]', file).split("\n")[0]
-        else
-          "#{file}:#{line}: #{msg} (#{rule})"
-        end
-      Overcommit::Hook::Message.new(type, file, line, text)
+    def parse_messages(output)
+      output.scan(MESSAGE_REGEX).map do |file, line, type, msg|
+        type = MESSAGE_TYPE_CATEGORIZER.call(type)
+        text = "#{file}:#{line}:#{type} #{msg}"
+        Overcommit::Hook::Message.new(type, file, line, text)
+      end
     end
   end
 end

--- a/spec/overcommit/hook/pre_commit/coffee_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/coffee_lint_spec.rb
@@ -19,9 +19,9 @@ describe Overcommit::Hook::PreCommit::CoffeeLint do
 
     context 'with no warnings' do
       before do
-        result.stub(:stdout).and_return('{
-          "file1.coffee": []
-        }')
+        result.stub(:stdout).and_return(normalize_indent(<<-OUT))
+          path,lineNumber,lineNumberEnd,level,message
+        OUT
       end
 
       it { should pass }
@@ -29,20 +29,10 @@ describe Overcommit::Hook::PreCommit::CoffeeLint do
 
     context 'and it reports a warning' do
       before do
-        result.stub(:stdout).and_return('{
-          "file1.coffee": [
-            {
-              "name": "ensure_comprehensions",
-              "level": "warn",
-              "message": "Comprehensions must have parentheses around them",
-              "description": "This rule makes sure that parentheses are around comprehensions.",
-              "context": "",
-              "lineNumber": 31,
-              "line": "cubes = math.cube num for num in list",
-              "rule": "ensure_comprehensions"
-            }
-          ]
-        }')
+        result.stub(:stdout).and_return(normalize_indent(<<-OUT))
+          path,lineNumber,lineNumberEnd,level,message
+          file1.coffee,31,,warn,Comprehensions must have parentheses around them
+        OUT
       end
 
       it { should warn }
@@ -59,27 +49,10 @@ describe Overcommit::Hook::PreCommit::CoffeeLint do
 
     context 'and it reports an error' do
       before do
-        result.stub(:stdout).and_return('{
-          "file1.coffee": [
-            {
-              "name": "duplicate_key",
-              "level": "error",
-              "message": "Duplicate key defined in object or class",
-              "description": "Prevents defining duplicate keys in object literals and classes",
-              "lineNumber": 17,
-              "line": "  root: foo",
-              "rule": "duplicate_key"
-            }
-          ]
-        }')
-      end
-
-      it { should fail_hook }
-    end
-
-    context 'and its output is not valid JSON' do
-      before do
-        result.stub(:stdout).and_return('foo')
+        result.stub(:stdout).and_return(normalize_indent(<<-OUT))
+          path,lineNumber,lineNumberEnd,level,message
+          file1.coffee,17,,error,Duplicate key defined in object or class
+        OUT
       end
 
       it { should fail_hook }


### PR DESCRIPTION
This allows us to remove the dependency on the 'json' library and
simplify the message parsing logic. It also makes it easier to parse
concatenated results of multiple calls when splitting argument lists.