### PR TITLE
Mention `OVERCOMMIT_DEBUG=1` in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,9 @@
 * Include the steps you carried out to produce the problem.
 * Include the behavior you observed along with the behavior you expected, and
   why you expected it.
-* Include the stack trace reported by Overcommit if there is one.
+* Try setting the `OVERCOMMIT_DEBUG` environment variable to enable the display
+  of additional verbose output from executed commands.
+* Include the stack trace and any debugging output reported by Overcommit.
 
 ## Feature Requests
 


### PR DESCRIPTION
In 0.27.0 we added support for the `OVERCOMMIT_DEBUG` environment
variable which toggles the display of verbose output from executed
commands, but didn't document it anywhere. This setting might help
people debug their problems and submit more informative bug reports, so
documenting it here seems to make sense.