### PR TITLE
Add NginxTest pre-commit hook to test nginx configs

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -322,6 +322,13 @@ PreCommit:
     required_executable: 'grep'
     flags: ['-IHn', "^<<<<<<<[ \t]"]
 
+  NginxTest:
+    enabled: false
+    description: 'Testing nginx configs'
+    required_executable: 'nginx'
+    flags: ['-t']
+    include: '**/nginx.conf'
+
   Pep257:
     enabled: false
     description: 'Analyzing docstrings with pep257'

--- a/lib/overcommit/hook/pre_commit/nginx_test.rb
+++ b/lib/overcommit/hook/pre_commit/nginx_test.rb
@@ -1,0 +1,24 @@
+module Overcommit::Hook::PreCommit
+  # Runs `nginx -t` against any modified Nginx config files.
+  #
+  # @see https://www.nginx.com/resources/wiki/start/topics/tutorials/commandline/
+  class NginxTest < Base
+    MESSAGE_REGEX = /^nginx: .+ in (?<file>.+):(?<line>\d+)$/
+
+    def run
+      messages = []
+
+      applicable_files.each do |file|
+        result = execute(command + ['-c', file])
+        next if result.success?
+
+        messages += extract_messages(
+          result.stderr.split("\n").grep(MESSAGE_REGEX),
+          MESSAGE_REGEX
+        )
+      end
+
+      messages
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_commit/nginx_test_spec.rb
+++ b/spec/overcommit/hook/pre_commit/nginx_test_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::NginxTest do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  let(:result) { double('result') }
+
+  before do
+    subject.stub(:applicable_files).and_return(%w[nginx.conf])
+    subject.stub(:execute).and_return(result)
+  end
+
+  context 'when nginx -t exits successfully' do
+    before do
+      result.stub(:success?).and_return(true)
+    end
+
+    it { should pass }
+  end
+
+  context 'when nginx -t exits unsuccessfully' do
+    let(:result) { double('result') }
+
+    before do
+      result.stub(success?: false, stderr: normalize_indent(<<-OUT))
+        nginx: [emerg] unknown directive "erver" in nginx.conf:2
+        nginx: configuration file nginx.conf test failed
+      OUT
+    end
+
+    it { should fail_hook }
+  end
+end


### PR DESCRIPTION
Finally got around to this. The hook uses `nginx -t` on each config file individually and aggregates any errors.

Closes #255