### PR TITLE
Fix tests with git diff.renames option set

### DIFF
--- a/lib/overcommit/git_repo.rb
+++ b/lib/overcommit/git_repo.rb
@@ -92,7 +92,7 @@ module Overcommit
       refs = options[:refs]
       subcmd = options[:subcmd] || 'diff'
 
-      `git #{subcmd} --name-only -z --diff-filter=ACM --ignore-submodules=all #{flags} #{refs}`.
+      `git #{subcmd} --name-only -z --diff-filter=ACMR --ignore-submodules=all #{flags} #{refs}`.
         split("\0").
         map(&:strip).
         reject(&:empty?).


### PR DESCRIPTION
If the ~/.gitconfig sets the `diff.renames` option to a true value 4 of
the 5 tests run with `rspec -d renam` fail.  Fix this by adding `R` to
the list of change types included in the `--diff-filter` option.  All
tests continue to pass if this option is left at the default value.