### PR TITLE
Run hooks in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Option                                  | Description
 `flags`                                 | Array of arguments to append to the `command`. This is useful for customizing the behavior of a tool. It's also useful when a newer version of a tool removes/renames existing flags, so you can update the flags via your `.overcommit.yml` instead of waiting for an upstream fix in Overcommit.
 `env`                                   | Hash of environment variables the hook should be run with. This is intended to be used as a last resort when an executable a hook runs is configured only via an environment variable. Any pre-existing environment variables with the same names as ones defined in `env` will have their original values restored after the hook runs. **WARNING**: If you set the same environment variable for multiple hooks and you've enabled parallel hook runs, since the environment is shared across all threads you could accidentally have these separate hooks trample on each other. In this case, you should disable parallelization for the hook using the `parallelize` option.
 `parallelize`                           | Whether to allow this hook to be run concurrently with other hooks. Disable this if the hook requires access to a shared resource that other hooks may also access and modify (e.g. files, the git index, process environment variables, etc).
+`processors`                            | The number of processing units to reserve for this hook. This does not reserve CPUs, but indicates that out of the total number of possible concurrent hooks allowed by the global `concurrency` option, this hook requires the specified number. Thus in the typical case where `concurrency` is set to the number of available cores (default), and you have a hook that executes an application which itself creates 2 threads (or is otherwise scheduled on 2 cores), you can indicate that Overcommit should allocate 2 `processors` to the hook. Ideally this means your hooks won't put undue load on your available cores.
 `install_command`                       | Command the user can run to install the `required_executable` (or alternately the specified `required_libraries`). This is intended for documentation purposes, as Overcommit does not install software on your behalf since there are too many edge cases where such behavior would result in incorrectly configured installations (e.g. installing a Python package in the global package space instead of in a virtual environment).
 
 In addition to the built-in configuration options, each hook can expose its
@@ -333,6 +334,10 @@ mathematical expressions, e.g. `%{processors} * 2`, or `%{processors} / 2`.
 ```yaml
 concurrency: '%{processors} / 4'
 ```
+
+Note that individual hooks can specify the number of processors they require
+with the `processors` hook option. See the [hook options](#hook-options)
+section for more details.
 
 ### Signature Verification
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -39,6 +39,13 @@ gemfile: false
 # to the root of the repository.
 plugin_directory: '.git-hooks'
 
+# Number of hooks that can be run concurrently. Typically this won't need to be
+# adjusted, but if you know that some of your hooks themselves use multiple
+# processors you can lower this value accordingly. You can define
+# single-operator mathematical expressions, e.g. '%{processors} * 2', or
+# '%{processors} / 2'.
+concurrency: '%{processors}'
+
 # Whether to check if a hook plugin has changed since Overcommit last ran it.
 # This is a defense mechanism when working with repositories which can contain
 # untrusted code (e.g. when you fetch a pull request from a third party).

--- a/lib/overcommit/configuration.rb
+++ b/lib/overcommit/configuration.rb
@@ -34,6 +34,23 @@ module Overcommit
       File.join(Overcommit::Utils.repo_root, @hash['plugin_directory'] || '.git-hooks')
     end
 
+    def concurrency
+      @concurrency ||=
+        begin
+          cores = Overcommit::Utils.processor_count
+          concurrency_expr = @hash.fetch('concurrency', '%{processors}') % {
+            processors: cores,
+          }
+
+          a, op, b = concurrency_expr.scan(%r{(\d+)\s*([+\-*\/])\s*(\d+)})[0]
+          if a
+            a.to_i.send(op, b.to_i)
+          else
+            concurrency_expr.to_i
+          end
+        end
+    end
+
     # Returns configuration for all hooks in each hook type.
     #
     # @return [Hash]

--- a/lib/overcommit/configuration_validator.rb
+++ b/lib/overcommit/configuration_validator.rb
@@ -3,12 +3,13 @@ module Overcommit
   class ConfigurationValidator
     # Validates hash for any invalid options, normalizing where possible.
     #
+    # @param config [Overcommit::Configuration]
     # @param hash [Hash] hash representation of YAML config
     # @param options[Hash]
     # @option default [Boolean] whether hash represents the default built-in config
     # @option logger [Overcommit::Logger] logger to output warnings to
     # @return [Hash] validated hash (potentially modified)
-    def validate(hash, options)
+    def validate(config, hash, options)
       @options = options.dup
       @log = options[:logger]
 
@@ -16,6 +17,7 @@ module Overcommit
       ensure_hook_type_sections_exist(hash)
       check_hook_name_format(hash)
       check_for_missing_enabled_option(hash) unless @options[:default]
+      check_for_too_many_processors(config, hash)
       check_for_verify_plugin_signatures_option(hash)
 
       hash
@@ -94,6 +96,31 @@ module Overcommit
       end
 
       @log.newline if any_warnings
+    end
+
+    # Prints a warning if any hook has a number of processors larger than the
+    # global `concurrency` setting.
+    def check_for_too_many_processors(config, hash)
+      concurrency = config.concurrency
+
+      errors = []
+      Overcommit::Utils.supported_hook_type_classes.each do |hook_type|
+        hash.fetch(hook_type, {}).each do |hook_name, hook_config|
+          processors = hook_config.fetch('processors', 1)
+          if processors > concurrency
+            errors << "#{hook_type}::#{hook_name} `processors` value " \
+                      "(#{processors}) is larger than the global `concurrency` " \
+                      "option (#{concurrency})"
+          end
+        end
+      end
+
+      if errors.any?
+        @log.error errors.join("\n") if @log
+        @log.newline if @log
+        raise Overcommit::Exceptions::ConfigurationError,
+              'One or more hooks had invalid `processor` value configured'
+      end
     end
 
     # Prints a warning if the `verify_plugin_signatures` option is used instead

--- a/lib/overcommit/hook/base.rb
+++ b/lib/overcommit/hook/base.rb
@@ -61,6 +61,10 @@ module Overcommit::Hook
       @config['required']
     end
 
+    def parallelize?
+      @config['parallelize'] != false
+    end
+
     def quiet?
       @config['quiet']
     end

--- a/lib/overcommit/hook/base.rb
+++ b/lib/overcommit/hook/base.rb
@@ -65,6 +65,10 @@ module Overcommit::Hook
       @config['parallelize'] != false
     end
 
+    def processors
+      @config.fetch('processors', 1)
+    end
+
     def quiet?
       @config['quiet']
     end

--- a/lib/overcommit/hook_runner.rb
+++ b/lib/overcommit/hook_runner.rb
@@ -103,7 +103,7 @@ module Overcommit
       @lock.synchronize do
         @main.signal # Tell the main thread that we're ready to run
         @hooks_ready += 1
-        slots_needed = hook.parallelize? ? 1 : @config.concurrency
+        slots_needed = hook.parallelize? ? hook.processors : @config.concurrency
 
         loop do
           @resource.wait(@lock)
@@ -123,7 +123,7 @@ module Overcommit
 
     def release_slot(hook)
       @lock.synchronize do
-        slots_released = hook.parallelize? ? 1 : @config.concurrency
+        slots_released = hook.parallelize? ? hook.processors : @config.concurrency
         @slots_available += slots_released
         @hooks_finished += 1
 

--- a/lib/overcommit/utils.rb
+++ b/lib/overcommit/utils.rb
@@ -211,6 +211,42 @@ module Overcommit
         Subprocess.spawn_detached(args)
       end
 
+      # Return the number of processors used by the OS for process scheduling.
+      #
+      # @see https://github.com/grosser/parallel/blob/v1.6.1/lib/parallel/processor_count.rb#L17-L51
+      def processor_count # rubocop:disable all
+        @processor_count ||=
+          begin
+            if Overcommit::OS.windows?
+              require 'win32ole'
+              result = WIN32OLE.connect('winmgmts://').ExecQuery(
+                'select NumberOfLogicalProcessors from Win32_Processor')
+              result.to_enum.collect(&:NumberOfLogicalProcessors).reduce(:+)
+            elsif File.readable?('/proc/cpuinfo')
+              IO.read('/proc/cpuinfo').scan(/^processor/).size
+            elsif File.executable?('/usr/bin/hwprefs')
+              IO.popen('/usr/bin/hwprefs thread_count').read.to_i
+            elsif File.executable?('/usr/sbin/psrinfo')
+              IO.popen('/usr/sbin/psrinfo').read.scan(/^.*on-*line/).size
+            elsif File.executable?('/usr/sbin/ioscan')
+              IO.popen('/usr/sbin/ioscan -kC processor') do |out|
+                out.read.scan(/^.*processor/).size
+              end
+            elsif File.executable?('/usr/sbin/pmcycles')
+              IO.popen('/usr/sbin/pmcycles -m').read.count("\n")
+            elsif File.executable?('/usr/sbin/lsdev')
+              IO.popen('/usr/sbin/lsdev -Cc processor -S 1').read.count("\n")
+            elsif File.executable?('/usr/sbin/sysctl')
+              IO.popen('/usr/sbin/sysctl -n hw.ncpu').read.to_i
+            elsif File.executable?('/sbin/sysctl')
+              IO.popen('/sbin/sysctl -n hw.ncpu').read.to_i
+            else
+              # Unknown platform; assume 1 processor
+              1
+            end
+          end
+      end
+
       # Calls a block of code with a modified set of environment variables,
       # restoring them once the code has executed.
       def with_environment(env)

--- a/spec/overcommit/configuration_validator_spec.rb
+++ b/spec/overcommit/configuration_validator_spec.rb
@@ -2,10 +2,12 @@ require 'spec_helper'
 
 describe Overcommit::ConfigurationValidator do
   let(:options) { {} }
-  subject { described_class.new.validate(config, options) }
+  let(:config) { Overcommit::Configuration.new(config_hash, validate: false) }
+
+  subject { described_class.new.validate(config, config_hash, options) }
 
   context 'when hook has an invalid name' do
-    let(:config) do
+    let(:config_hash) do
       {
         'PreCommit' => {
           'My_Hook' => {
@@ -17,6 +19,46 @@ describe Overcommit::ConfigurationValidator do
 
     it 'raises an error' do
       expect { subject }.to raise_error Overcommit::Exceptions::ConfigurationError
+    end
+  end
+
+  context 'when hook has `processors` set' do
+    let(:concurrency) { 4 }
+
+    let(:config_hash) do
+      {
+        'concurrency' => concurrency,
+        'PreCommit' => {
+          'MyHook' => {
+            'enabled' => true,
+            'processors' => processors,
+          },
+        },
+      }
+    end
+
+    context 'and it is larger than `concurrency`' do
+      let(:processors) { concurrency + 1 }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error Overcommit::Exceptions::ConfigurationError
+      end
+    end
+
+    context 'and it is equal to `concurrency`' do
+      let(:processors) { concurrency }
+
+      it 'is valid' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'and it is less than `concurrency`' do
+      let(:processors) { concurrency - 1 }
+
+      it 'is valid' do
+        expect { subject }.not_to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
Add support for running hooks in parallel.

This has been on the [todo](https://github.com/brigade/overcommit/issues/144) list for a while, and while I'm not satisfied with this implementation I think it helps push us forward.

I went with bare threads instead of Celluloid because Celluloid supports only Ruby 2.0+ and I think it was pretty heavyweight for what we're trying to do here.

The biggest challenge here is dealing with interrupts, which is why you see `rescue Interrupt` in a number of places. Since signals aren't yet supported for multi-threaded applications (see the documentation for `Thread.handle_interrupt`), we need to handle a lot of this explicitly.

The output has changed slightly: since we don't run hooks serially, we have to wait until they finish before displaying anything (or else their output is interleaved). I looked into ways of updating the output after the fact (by manipulating the terminal cursor) but it became clear that would be quite the undertaking, so I considered it out of scope.

I need to do some more testing, but putting this up for now so others can have a look and comment.