### PR TITLE
Simplify `BundleCheck` pre-commit hook

### DIFF
--- a/lib/overcommit/hook/pre_commit/bundle_check.rb
+++ b/lib/overcommit/hook/pre_commit/bundle_check.rb
@@ -16,11 +16,6 @@ module Overcommit::Hook::PreCommit
         return :fail, result.stdout
       end
 
-      result = execute(%w[git diff --quiet --] + [LOCK_FILE])
-      unless result.success?
-        return :fail, "#{LOCK_FILE} is not up-to-date -- run `#{command.join(' ')}`"
-      end
-
       :pass
     end
   end


### PR DESCRIPTION
That part of the hook throws offenses in cases when everything is fine.
Remove it.