### PR TITLE
Fix Appveyor badge url by replacing "brigade" with "sds"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Gem Version](https://badge.fury.io/rb/overcommit.svg)](https://badge.fury.io/rb/overcommit)
 [![Build Status](https://travis-ci.org/brigade/overcommit.svg?branch=master)](https://travis-ci.org/brigade/overcommit)
-[![Windows Build Status](https://ci.appveyor.com/api/projects/status/github/brigade/overcommit?branch=master&svg=true)](https://ci.appveyor.com/project/sds/overcommit)
+[![Windows Build Status](https://ci.appveyor.com/api/projects/status/github/sds/overcommit?branch=master&svg=true)](https://ci.appveyor.com/project/sds/overcommit)
 [![Coverage Status](https://coveralls.io/repos/brigade/overcommit/badge.svg)](https://coveralls.io/r/brigade/overcommit)
 [![Code Climate](https://codeclimate.com/github/brigade/overcommit.svg)](https://codeclimate.com/github/brigade/overcommit)
 [![Dependency Status](https://gemnasium.com/brigade/overcommit.svg)](https://gemnasium.com/brigade/overcommit)


### PR DESCRIPTION
The badge actually links to `sds/overcommit`, not `brigade/overcommit`. It shows the build as failing because there is no `brigade/overcommit` project on Appveyor.