### PR TITLE
Correctly fail hook when rubocop is not installed

### DIFF
--- a/lib/overcommit/hook/pre_commit/rubo_cop.rb
+++ b/lib/overcommit/hook/pre_commit/rubo_cop.rb
@@ -10,6 +10,7 @@ module Overcommit::Hook::PreCommit
     def run
       result = execute(command, args: applicable_files)
       return :pass if result.success?
+      return [:fail, result.stderr] unless result.stderr.empty?
 
       extract_messages(
         result.stdout.split("\n"),

--- a/spec/overcommit/hook/pre_commit/rubo_cop_spec.rb
+++ b/spec/overcommit/hook/pre_commit/rubo_cop_spec.rb
@@ -48,5 +48,16 @@ describe Overcommit::Hook::PreCommit::RuboCop do
 
       it { should fail_hook }
     end
+
+    context 'when there is an error running rubocop' do
+      before do
+        result.stub(:stdout).and_return('')
+        result.stub(:stderr).and_return([
+          'Could not find rubocop in any of the sources'
+        ].join("\n"))
+      end
+
+      it { should fail_hook }
+    end
   end
 end


### PR DESCRIPTION
When rubocop is not installed, or when the installed version does not match the version expected by Bundler, the 'pre_commit/rubo_cop' hook passes 100% of the time because 'result.stdout' is empty.

This commit updates the hook to fail if anything is present in stderr after the hook runs.

--

**Example:**  I have rubocop v0.29.1 installed locally, but a project's Gemfile.lock depends on v0.34.2. Running `bundle check` correctly identifies the problem:

```
Resolving dependencies......
The following gems are missing
 * rubocop (0.34.2)
Install missing gems with `bundle install`
```

But the overcommit `pre_commit/rubo_cop.rb` hook passes. We catch the rubocop warnings later on CI, but it would be nice to have overcommit surface them locally.
