### PR TITLE
Add basic support of rails_best_practices in pre-commit hooks

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -388,6 +388,12 @@ PreCommit:
     install_command: 'pip install flake8'
     include: '**/*.py'
 
+  RailsBestPractices:
+    enabled: false
+    description: 'Analyzing with RailsBestPractices'
+    required_executable: 'rails_best_practices'
+    install_command: 'gem install rails_best_practices'
+
   RailsSchemaUpToDate:
     enabled: false
     description: 'Checking if database schema is up to date'

--- a/lib/overcommit/hook/pre_commit/rails_best_practices.rb
+++ b/lib/overcommit/hook/pre_commit/rails_best_practices.rb
@@ -1,0 +1,32 @@
+module Overcommit
+  module Hook
+    module PreCommit
+      # Runs `rails_best_practices` against Ruby files
+      #
+      # @see https://github.com/railsbp/rails_best_practices
+      class RailsBestPractices < Base
+        ERROR_REGEXP = /^(?<file>(?:\w:)?[^:]+):(?<line>\d+)\s-\s(?<type>.+)/
+
+        def run
+          result = execute(command)
+
+          return :pass if result.success?
+          return [:fail, result.stderr] unless result.stderr.empty?
+
+          extract_messages(
+            filter_output(result.stdout),
+            ERROR_REGEXP
+          )
+        end
+
+        private
+
+        def filter_output(stdout)
+          stdout.split("\n").select do |message|
+            message.match ERROR_REGEXP
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_commit/rails_best_practices_spec.rb
+++ b/spec/overcommit/hook/pre_commit/rails_best_practices_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::RailsBestPractices do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  context 'when rails_best_practices exits successfully' do
+    before do
+      result = double('result')
+      result.stub(:success?).and_return(true)
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should pass }
+  end
+
+  context 'when rails_best_practices exits unsucessfully' do
+    let(:result) { double('result') }
+
+    before do
+      result.stub(:success?).and_return(false)
+      subject.stub(:execute).and_return(result)
+    end
+
+    context 'and it reports an error' do
+      before do
+        result.stub(:stdout).and_return([
+          'file1.rb:7 - simplify render in controllers',
+        ].join("\n"))
+        result.stub(:stderr).and_return('')
+      end
+
+      it { should fail_hook }
+    end
+
+    context 'when there is an error running rails_best_practices' do
+      before do
+        result.stub(:stdout).and_return('')
+        result.stub(:stderr).and_return([
+          'Something went wrong with rails_best_practices'
+        ].join("\n"))
+      end
+
+      it { should fail_hook }
+    end
+  end
+end


### PR DESCRIPTION
We were working on one Rails project with @paladiy and found out that `overcommit` had no support of `rails_best_practices` gem, so this is its basic integration.