### PR TITLE
Don't count newline against commit subject length

### DIFF
--- a/lib/overcommit/hook/commit_msg/text_width.rb
+++ b/lib/overcommit/hook/commit_msg/text_width.rb
@@ -7,7 +7,7 @@ module Overcommit::Hook::CommitMsg
 
       @errors = []
 
-      find_errors_in_subject(commit_message_lines.first)
+      find_errors_in_subject(commit_message_lines.first.chomp)
       find_errors_in_body(commit_message_lines)
 
       return :warn, @errors.join("\n") if @errors.any?

--- a/spec/overcommit/hook/commit_msg/text_width_spec.rb
+++ b/spec/overcommit/hook/commit_msg/text_width_spec.rb
@@ -28,6 +28,17 @@ describe Overcommit::Hook::CommitMsg::TextWidth do
     it { should pass }
   end
 
+  context 'when a line in the message is 72 characters followed by a newline' do
+    let(:commit_msg) { <<-MSG }
+      Some summary
+
+      This line has 72 characters, but with newline it has 73 characters
+      That shouldn't be a problem.
+    MSG
+
+    it { should pass }
+  end
+
   context 'when a line in the message is longer than 72 characters' do
     let(:commit_msg) { <<-MSG }
       Some summary

--- a/spec/overcommit/hook/commit_msg/text_width_spec.rb
+++ b/spec/overcommit/hook/commit_msg/text_width_spec.rb
@@ -6,7 +6,7 @@ describe Overcommit::Hook::CommitMsg::TextWidth do
   subject { described_class.new(config, context) }
 
   before do
-    context.stub(:commit_message_lines).and_return(commit_msg.split("\n"))
+    context.stub(:commit_message_lines).and_return(commit_msg.lines)
     context.stub(:empty_message?).and_return(commit_msg.empty?)
   end
 
@@ -24,6 +24,16 @@ describe Overcommit::Hook::CommitMsg::TextWidth do
 
   context 'when subject is 60 characters or fewer' do
     let(:commit_msg) { 'A' * 60 }
+
+    it { should pass }
+  end
+
+  context 'when the subject is 60 characters followed by a newline' do
+    let(:commit_msg) { <<-MSG }
+      This is 60 characters, or 61 if the newline is counted
+
+      A reasonable line.
+    MSG
 
     it { should pass }
   end


### PR DESCRIPTION
These changes apply to the `Overcommit::Hooks::CommitMsg::TextWidth` hook.

When specifying a `max_subject_width`, I expect to be able to type out a commit subject as long as the specified max width. However, because the hook counts the newline character, the hook fails.

This pull request takes the behavior used for the commit body -- i.e., not counting a trailing newline against the total width -- and applies that to the commit subject as well.