### PR TITLE
Fix failing tests on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,4 +66,5 @@ before_test:
 
 test_script:
   - bundle exec rspec --tty --backtrace --color --format documentation
+  - bundle exec overcommit --sign
   - bundle exec overcommit --run

--- a/lib/overcommit/os.rb
+++ b/lib/overcommit/os.rb
@@ -30,5 +30,7 @@ module Overcommit
         @os ||= ::RbConfig::CONFIG['host_os']
       end
     end
+
+    SEPARATOR = self.windows? ? '\\' : File::SEPARATOR
   end
 end

--- a/lib/overcommit/utils/file_utils.rb
+++ b/lib/overcommit/utils/file_utils.rb
@@ -58,7 +58,7 @@ module Overcommit::Utils
       end
 
       def win32_fix_pathsep(path)
-        path.tr('/', '\\')
+        path.tr(File::SEPARATOR, Overcommit::OS::SEPARATOR)
       end
 
       def win32_symlink?(dir_output)

--- a/spec/integration/run_flag_spec.rb
+++ b/spec/integration/run_flag_spec.rb
@@ -11,13 +11,14 @@ describe 'overcommit --run' do
       let(:script_name) { 'test-script' }
       let(:script_contents) { "#!/bin/bash\nexit 0" }
     end
+    let(:script_path) { ".#{Overcommit::OS::SEPARATOR}#{script_name}" }
 
     let(:config) do
       {
         'PreCommit' => {
           'MyHook' => {
             'enabled' => true,
-            'required_executable' => "./#{script_name}",
+            'required_executable' => script_path,
           }
         }
       }
@@ -26,9 +27,9 @@ describe 'overcommit --run' do
     around do |example|
       repo do
         File.open('.overcommit.yml', 'w') { |f| f.puts(config.to_yaml) }
-        echo(script_contents, script_name)
-        `git add #{script_name}`
-        FileUtils.chmod(0755, script_name)
+        echo(script_contents, script_path)
+        `git add #{script_path}`
+        FileUtils.chmod(0755, script_path)
         example.run
       end
     end

--- a/spec/overcommit/git_config_spec.rb
+++ b/spec/overcommit/git_config_spec.rb
@@ -7,7 +7,7 @@ describe Overcommit::GitConfig do
     context 'with no configuration' do
       it 'should be "#"' do
         repo do
-          `git config --local core.commentchar ''`
+          `git config --local core.commentchar ""`
           expect(subject).to eq '#'
         end
       end

--- a/spec/overcommit/hook_context/pre_commit_spec.rb
+++ b/spec/overcommit/hook_context/pre_commit_spec.rb
@@ -183,8 +183,8 @@ describe Overcommit::HookContext::PreCommit do
           `git submodule add #{submodule} sub > #{File::NULL} 2>&1`
           `git commit -m "Add submodule"`
           echo('Hello World', 'sub/submodule-file')
-          `git submodule foreach "git add submodule-file"`
-          `git submodule foreach "git commit -m \\"Another commit\\""`
+          `git submodule foreach "git add submodule-file" < #{File::NULL}`
+          `git submodule foreach "git commit -m \\"Another commit\\"" < #{File::NULL}`
           `git add sub`
           example.run
         end
@@ -337,8 +337,8 @@ describe Overcommit::HookContext::PreCommit do
           `git submodule add #{submodule} sub > #{File::NULL} 2>&1`
           `git commit -m "Add submodule"`
           echo('Hello World', 'sub/submodule-file')
-          `git submodule foreach "git add submodule-file"`
-          `git submodule foreach "git commit -m \\"Another commit\\""`
+          `git submodule foreach "git add submodule-file" < #{File::NULL}`
+          `git submodule foreach "git commit -m \\"Another commit\\"" < #{File::NULL}`
           `git add sub`
           example.run
         end
@@ -362,8 +362,8 @@ describe Overcommit::HookContext::PreCommit do
           `git submodule add #{submodule} sub > #{File::NULL} 2>&1`
           `git commit -m "Add submodule"`
           echo('Hello World', 'sub/submodule-file')
-          `git submodule foreach "git add submodule-file"`
-          `git submodule foreach "git commit -m \\"Another commit\\""`
+          `git submodule foreach "git add submodule-file" < #{File::NULL}`
+          `git submodule foreach "git commit -m \\"Another commit\\"" < #{File::NULL}`
           echo('Hello Again', 'tracked-file')
           `git add sub tracked-file`
           example.run


### PR DESCRIPTION
The `cmd` shell does not treat single-quotes as string delimiters, so we should always use double-quotes in system commands.

Something is wrong with `git-submodule` in the latest release of Git for Windows, so I've added the workaround suggested in git-for-windows/git#181 and in [this post on the mailing list](http://www.spinics.net/lists/git/msg264407.html).