### PR TITLE
ProtectedBranches: match glob patterns

### DIFF
--- a/lib/overcommit/hook_context/pre_push.rb
+++ b/lib/overcommit/hook_context/pre_push.rb
@@ -30,6 +30,10 @@ module Overcommit::HookContext
         local_sha1 == '0' * 40
       end
 
+      def destructive?
+        deleted? || forced?
+      end
+
       def to_s
         "#{local_ref} #{local_sha1} #{remote_ref} #{remote_sha1}"
       end

--- a/spec/overcommit/hook/pre_push/protected_branches_spec.rb
+++ b/spec/overcommit/hook/pre_push/protected_branches_spec.rb
@@ -1,76 +1,69 @@
 require 'spec_helper'
+require 'overcommit/hook_context/pre_push'
 
 describe Overcommit::Hook::PrePush::ProtectedBranches do
   let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
   let(:context) { double('context') }
   subject { described_class.new(config, context) }
 
-  let(:protected_branch) { 'master' }
-  let(:unprotected_branch) { 'other' }
-  let(:pushed_ref) { double('pushed_ref') }
+  let(:protected_branch_patterns) { ['master', 'release/*'] }
+  let(:pushed_ref) do
+    instance_double(Overcommit::HookContext::PrePush::PushedRef)
+  end
 
   before do
-    subject.stub(:branches).and_return([protected_branch])
+    subject.stub(protected_branch_patterns: protected_branch_patterns)
+    pushed_ref.stub(:remote_ref).and_return("refs/heads/#{pushed_ref_name}")
     context.stub(:pushed_refs).and_return([pushed_ref])
   end
 
   context 'when pushing to unprotected branch' do
-    before do
-      pushed_ref.stub(:remote_ref).and_return("refs/heads/#{unprotected_branch}")
-    end
+    let(:pushed_ref_name) { 'unprotected-branch' }
 
-    context 'when ref is not deleted or force-pushed' do
+    context 'when push is not destructive' do
       before do
-        pushed_ref.stub(deleted?: false, forced?: false)
+        pushed_ref.stub(:destructive?).and_return(false)
       end
 
       it { should pass }
     end
 
-    context 'when ref is deleted' do
+    context 'when push is destructive' do
       before do
-        pushed_ref.stub(deleted?: true)
-      end
-
-      it { should pass }
-    end
-
-    context 'when ref is force-pushed' do
-      before do
-        pushed_ref.stub(deleted?: false, forced?: true)
+        pushed_ref.stub(:destructive?).and_return(true)
       end
 
       it { should pass }
     end
   end
 
-  context 'when pushing to protected branch' do
-    before do
-      pushed_ref.stub(:remote_ref).and_return("refs/heads/#{protected_branch}")
-    end
-
-    context 'when ref is not deleted or force-pushed' do
+  shared_examples_for 'protected branch' do
+    context 'when push is not destructive' do
       before do
-        pushed_ref.stub(deleted?: false, forced?: false)
+        pushed_ref.stub(:destructive?).and_return(false)
       end
 
       it { should pass }
     end
 
-    context 'when ref is deleted' do
+    context 'when push is destructive' do
       before do
-        pushed_ref.stub(deleted?: true)
+        pushed_ref.stub(:destructive?).and_return(true)
       end
 
       it { should fail_hook }
     end
+  end
 
-    context 'when ref is force-pushed' do
-      before do
-        pushed_ref.stub(deleted?: false, forced?: true)
-      end
+  context 'when pushing to protected branch' do
+    context 'when branch name matches a protected branch exactly' do
+      let(:pushed_ref_name) { 'master' }
+      include_examples 'protected branch'
+    end
 
-      it { should fail_hook }
+    context 'when branch name matches a protected branch glob pattern' do
+      let(:pushed_ref_name) { 'release/0.1.0' }
+      include_examples 'protected branch'
     end
   end
 end

--- a/spec/overcommit/hook_context/pre_push_spec.rb
+++ b/spec/overcommit/hook_context/pre_push_spec.rb
@@ -130,5 +130,33 @@ describe Overcommit::HookContext::PrePush do
         it { should == false }
       end
     end
+
+    describe '#destructive?' do
+      subject { pushed_ref.destructive? }
+
+      context 'when deleting a ref' do
+        before do
+          pushed_ref.stub(:deleted?).and_return(true)
+        end
+
+        it { should == true }
+      end
+
+      context 'when force-pushing a ref' do
+        before do
+          pushed_ref.stub(deleted?: false, forced?: true)
+        end
+
+        it { should == true }
+      end
+
+      context 'when not deleting or force-pushing a ref' do
+        before do
+          pushed_ref.stub(deleted?: false, forced?: false)
+        end
+
+        it { should == false }
+      end
+    end
   end
 end


### PR DESCRIPTION
This also introduces a new config option `branch_patterns` for `ProtectedBranches`. Its value will be merged with that of `branches` for backwards-compatibility.

Closes #289 (used globs instead of regexes, as that seems a bit more user-friendly).