### PR TITLE
Add mdl pre-commit hook

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -324,6 +324,13 @@ PreCommit:
     flags: ['-IHnE', "^[^#]*((\\bpath:)|(:path[ \t]*=>))"]
     include: '**/Gemfile'
 
+  Mdl:
+    enabled: false
+    description: 'Analyzing with mdl'
+    required_executable: 'mdl'
+    install_command: 'gem install mdl'
+    include: '**/*.md'
+
   MergeConflicts:
     enabled: true
     description: 'Checking for merge conflicts'

--- a/lib/overcommit/hook/pre_commit/mdl.rb
+++ b/lib/overcommit/hook/pre_commit/mdl.rb
@@ -1,0 +1,23 @@
+module Overcommit::Hook::PreCommit
+  # Runs `mdl` against any modified Markdown files
+  #
+  # @see https://github.com/mivok/markdownlint
+  class Mdl < Base
+    MESSAGE_REGEX = /^(?<file>(?:\w:)?[^:]+):(?<line>\d+)/
+
+    def run
+      result = execute(command, args: applicable_files)
+      output = result.stdout.chomp
+
+      return :pass if result.success?
+      return [:fail, result.stderr] unless result.stderr.empty?
+
+      # example message:
+      #   path/to/file.md:1: MD001 Error message
+      extract_messages(
+        output.split("\n"),
+        MESSAGE_REGEX
+      )
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_commit/mdl_spec.rb
+++ b/spec/overcommit/hook/pre_commit/mdl_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::Mdl do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  let(:result) { double('result') }
+
+  before do
+    result.stub(success?: success, stdout: stdout, stderr: stderr)
+    subject.stub(:applicable_files).and_return(%w[file1.md file2.md])
+    subject.stub(:execute).and_return(result)
+  end
+
+  context 'when mdl exits successfully' do
+    let(:success) { true }
+    let(:stdout) { '' }
+    let(:stderr) { '' }
+
+    it { should pass }
+  end
+
+  context 'when mdl exits unsuccessfully' do
+    let(:success) { false }
+
+    context 'and it reports an error' do
+      let(:stdout) { 'file1.md:1: MD013 Line length' }
+      let(:stderr) { '' }
+
+      it { should fail_hook }
+    end
+
+    context 'when there is an error running mdl' do
+      let(:stdout) { '' }
+      let(:stderr) { 'Some runtime error' }
+
+      it { should fail_hook }
+    end
+  end
+end


### PR DESCRIPTION
Analyze Markdown files with [mdl/markdownlint][mdl]

[mdl]: https://github.com/mivok/markdownlint

---

Note: The gem is called `mdl`, but the repo is called `markdownlint`. Figured I'd name the hook after the gem, but let me know if I should use `markdownlint` instead.