### PR TITLE
Add pre-commit hook ForbiddenBranches

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -217,6 +217,12 @@ PreCommit:
     description: 'Checking for file execute permissions'
     quiet: true
 
+  ForbiddenBranches:
+    enabled: false
+    description: 'Checking for commit to forbidden branch'
+    quiet: true
+    branch_patterns: ['master']
+
   GoLint:
     enabled: false
     description: 'Analyzing with golint'

--- a/lib/overcommit/git_repo.rb
+++ b/lib/overcommit/git_repo.rb
@@ -266,5 +266,11 @@ module Overcommit
         split(/\s+/).
         reject { |s| s.empty? || s == '*' }
     end
+
+    # Returns the name of the currently checked out branch.
+    # @return [String]
+    def current_branch
+      `git symbolic-ref --short -q HEAD`.chomp
+    end
   end
 end

--- a/lib/overcommit/hook/pre_commit/forbidden_branches.rb
+++ b/lib/overcommit/hook/pre_commit/forbidden_branches.rb
@@ -1,0 +1,24 @@
+module Overcommit::Hook::PreCommit
+  # Prevents commits to branches matching one of the configured patterns.
+  class ForbiddenBranches < Base
+    def run
+      return :pass unless forbidden_commit?
+
+      [:fail, "Committing to #{current_branch} is forbidden"]
+    end
+
+    private
+
+    def forbidden_commit?
+      forbidden_branch_patterns.any? { |p| File.fnmatch(p, current_branch) }
+    end
+
+    def forbidden_branch_patterns
+      @forbidden_branch_patterns ||= Array(config['branch_patterns'])
+    end
+
+    def current_branch
+      @current_branch ||= Overcommit::GitRepo.current_branch
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_commit/forbidden_branches_spec.rb
+++ b/spec/overcommit/hook/pre_commit/forbidden_branches_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::ForbiddenBranches do
+  let(:default_config) { Overcommit::ConfigurationLoader.default_configuration }
+  let(:branch_patterns) { ['master', 'release/*'] }
+  let(:config) do
+    default_config.merge(Overcommit::Configuration.new(
+      'PreCommit' => {
+        'ForbiddenBranches' => {
+          'branch_patterns' => branch_patterns
+        }
+      }))
+  end
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  around do |example|
+    repo do
+      `git checkout -b #{current_branch} > #{File::NULL} 2>&1`
+      example.run
+    end
+  end
+
+  context 'when committing to a permitted branch' do
+    let(:current_branch) { 'permitted' }
+    it { should pass }
+  end
+
+  context 'when committing to a forbidden branch' do
+    context 'when branch name matches a forbidden branch exactly' do
+      let(:current_branch) { 'master' }
+      it { should fail_hook }
+    end
+
+    context 'when branch name matches a forbidden branch glob pattern' do
+      let(:current_branch) { 'release/1.0' }
+      it { should fail_hook }
+    end
+  end
+end


### PR DESCRIPTION
This hook fails on an attempt to commit to a branch matching any of the glob patterns specified in the `branch_patterns` hook setting.

Closes #327