### PR TITLE
Print hook information before running it

### DIFF
--- a/lib/overcommit/hook_runner.rb
+++ b/lib/overcommit/hook_runner.rb
@@ -145,6 +145,8 @@ module Overcommit
     def run_hook(hook) # rubocop:disable Metrics/CyclomaticComplexity
       status, output = nil, nil
 
+      @printer.begin_hook(hook) unless @interrupted
+
       begin
         wait_for_slot(hook)
         return if should_skip?(hook)

--- a/lib/overcommit/printer.rb
+++ b/lib/overcommit/printer.rb
@@ -32,11 +32,16 @@ module Overcommit
       log.warning "Cannot skip #{hook.name} since it is required"
     end
 
+    # Executed at the beginning of an individual hook run.
+    def begin_hook(hook)
+      print_header(hook) unless hook.quiet?
+    end
+
     # Executed at the end of an individual hook run.
     def end_hook(hook, status, output)
       # Want to print the header for quiet hooks only if the result wasn't good
       # so that the user knows what failed
-      print_header(hook) if !hook.quiet? || status != :pass
+      print_header(hook) if hook.quiet? && status != :pass
 
       print_result(hook, status, output)
     end


### PR DESCRIPTION
Pre-push hooks that run tests can take a while to execute. Currently
"Running pre-push hooks" is printed and only after running the hook,
"Running Minitest test suite................................[Minitest]
 OK" is printed.

I think it's better to print "Running Minitest test suite..............
..................[Minitest]" before running the hook, and add the
status string afterwards.