### PR TITLE
Don't fail on empty message in MessageFormat hook

### DIFF
--- a/lib/overcommit/hook/commit_msg/message_format.rb
+++ b/lib/overcommit/hook/commit_msg/message_format.rb
@@ -2,8 +2,6 @@ module Overcommit::Hook::CommitMsg
   # Ensures the commit message follows a specific format.
   class MessageFormat < Base
     def run
-      return :fail, "Empty message not allowed." if empty_message?
-
       error_msg = validate_pattern(commit_message_lines.join("\n"))
       return :fail, error_msg if error_msg
 

--- a/spec/overcommit/hook/commit_msg/message_format_spec.rb
+++ b/spec/overcommit/hook/commit_msg/message_format_spec.rb
@@ -10,12 +10,6 @@ describe Overcommit::Hook::CommitMsg::MessageFormat do
     context.stub(:empty_message?).and_return(commit_msg.empty?)
   end
 
-  context 'when commit message is empty' do
-    let(:commit_msg) { '' }
-
-    it { should fail_hook }
-  end
-
   context 'when pattern is empty' do
     let(:config) do
       super().merge(Overcommit::Configuration.new(


### PR DESCRIPTION
The `EmptyMessage` hook already covers this case.