### PR TITLE
Add GitLfs PrePush hook to replace the stock hook installed by `git lfs install`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -829,6 +829,11 @@ PrePush:
     command: ['ruby', '-Ilib:test', '-rminitest', "-e 'exit! Minitest.run'"]
     include: 'test/**/*_test.rb'
 
+  GitLfs:
+    enabled: false
+    description: 'Replacement for Git Lfs pre_push hook'
+    required_executable: 'git-lfs'
+
 # Hooks that run during `git rebase`, before any commits are rebased.
 # If a hook fails, the rebase is aborted.
 PreRebase:

--- a/lib/overcommit/hook/pre_push/git_lfs.rb
+++ b/lib/overcommit/hook/pre_push/git_lfs.rb
@@ -1,0 +1,43 @@
+module Overcommit::Hook::PrePush
+  # Replaces the pre-push hook installed by `git lfs install` that is then moved aside by
+  # `overcommit --install`
+  #
+  # Enable this hook in .overcommit.yml like so:
+  #
+  #  PrePush:
+  #    GitLfs:
+  #      enabled: true
+  #      command: ['git', 'lfs', 'pre-push']
+  #
+  # @see https://github.com/github/git-lfs
+  class GitLfs < Base
+    # Overcommit expects you to override this method which will be called
+    # everytime your pre-commit hook is run.
+    def run
+      # Create two arrays to hold our error and warning messages.
+      error_lines = []
+      warning_lines = []
+
+      # Check if git-lfs executable exists
+      path_to_git_lfs = `command -v git-lfs`.strip
+      error_lines << "This repository is configured for Git LFS but 'git-lfs' was not found "\
+                     "on your path. If you no longer wish to use Git LFS, disable GitLfs in "\
+                     ".overcommit.yml." unless File.exist?(path_to_git_lfs)
+
+      result = execute(command)
+      error_lines << "'#{command}' returned non-zero exit status: #{result.status}" unless
+        result.success?
+
+      # Overcommit expects 1 of the 3 as return values, `:fail`, `:warn` or `:pass`.
+      # If the hook returns `:fail`, the commit will be aborted with our message
+      # containing the errors.
+      return :fail, error_lines.join("\n") if error_lines.any?
+
+      :pass
+    end
+
+    def command
+      super + ["#{remote_name}", "#{remote_url}"]
+    end
+  end
+end

--- a/lib/overcommit/hook/pre_push/git_lfs.rb
+++ b/lib/overcommit/hook/pre_push/git_lfs.rb
@@ -24,7 +24,7 @@ module Overcommit::Hook::PrePush
                      "on your path. If you no longer wish to use Git LFS, disable GitLfs in "\
                      ".overcommit.yml." unless File.exist?(path_to_git_lfs)
 
-      result = execute(command)
+      result = execute(command, input: pushed_refs)
       error_lines << "'#{command}' returned non-zero exit status: #{result.status}" unless
         result.success?
 

--- a/lib/overcommit/hook/pre_push/git_lfs.rb
+++ b/lib/overcommit/hook/pre_push/git_lfs.rb
@@ -2,42 +2,12 @@ module Overcommit::Hook::PrePush
   # Replaces the pre-push hook installed by `git lfs install` that is then moved aside by
   # `overcommit --install`
   #
-  # Enable this hook in .overcommit.yml like so:
-  #
-  #  PrePush:
-  #    GitLfs:
-  #      enabled: true
-  #      command: ['git', 'lfs', 'pre-push']
-  #
   # @see https://github.com/github/git-lfs
   class GitLfs < Base
-    # Overcommit expects you to override this method which will be called
-    # everytime your pre-commit hook is run.
     def run
-      # Create two arrays to hold our error and warning messages.
-      error_lines = []
-      warning_lines = []
-
-      # Check if git-lfs executable exists
-      path_to_git_lfs = `command -v git-lfs`.strip
-      error_lines << "This repository is configured for Git LFS but 'git-lfs' was not found "\
-                     "on your path. If you no longer wish to use Git LFS, disable GitLfs in "\
-                     ".overcommit.yml." unless File.exist?(path_to_git_lfs)
-
-      result = execute(command, input: pushed_refs)
-      error_lines << "'#{command}' returned non-zero exit status: #{result.status}" unless
-        result.success?
-
-      # Overcommit expects 1 of the 3 as return values, `:fail`, `:warn` or `:pass`.
-      # If the hook returns `:fail`, the commit will be aborted with our message
-      # containing the errors.
-      return :fail, error_lines.join("\n") if error_lines.any?
-
+      result = execute(command, args: ['pre-push', remote_name, remote_url], input: @context.input_string)
+      return :fail, result.stdout + result.stderr unless result.success?
       :pass
-    end
-
-    def command
-      super + ["#{remote_name}", "#{remote_url}"]
     end
   end
 end

--- a/spec/overcommit/hook/pre_push/git_lfs_spec.rb
+++ b/spec/overcommit/hook/pre_push/git_lfs_spec.rb
@@ -7,7 +7,7 @@ describe Overcommit::Hook::PrePush::GitLfs do
            all_files: ['test/test_foo.rb'],
            remote_name: 'origin',
            remote_url: 'https://github.io/brigade/fake_repo',
-           pushed_refs: 'refs/heads/master master'
+           input_string: 'refs/heads/master master'
           )}
   subject { described_class.new(config, context) }
 
@@ -23,7 +23,7 @@ describe Overcommit::Hook::PrePush::GitLfs do
   end
 
   context 'when git_lfs exits unsuccessfully' do
-    let(:result) { double('result', status: -1) }
+    let(:result) { double('result', stdout: "Failed running git-lfs", stderr: "Failed running git-lfs") }
 
     before do
       result.stub(:success?).and_return(false)

--- a/spec/overcommit/hook/pre_push/git_lfs_spec.rb
+++ b/spec/overcommit/hook/pre_push/git_lfs_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PrePush::GitLfs do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context', all_files: ['test/test_foo.rb'], remote_name: 'origin', remote_url: 'https://github.io/brigade/fake_repo') }
+  subject { described_class.new(config, context) }
+
+  context 'when git_lfs exits successfully' do
+    let(:result) { double('result') }
+
+    before do
+      result.stub(:success?).and_return(true)
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should pass }
+  end
+
+  context 'when git_lfs exits unsuccessfully' do
+    let(:result) { double('result', status: -1) }
+
+    before do
+      result.stub(:success?).and_return(false)
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should fail_hook }
+  end
+end

--- a/spec/overcommit/hook/pre_push/git_lfs_spec.rb
+++ b/spec/overcommit/hook/pre_push/git_lfs_spec.rb
@@ -2,7 +2,13 @@ require 'spec_helper'
 
 describe Overcommit::Hook::PrePush::GitLfs do
   let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
-  let(:context) { double('context', all_files: ['test/test_foo.rb'], remote_name: 'origin', remote_url: 'https://github.io/brigade/fake_repo') }
+  let(:context) {
+    double('context',
+           all_files: ['test/test_foo.rb'],
+           remote_name: 'origin',
+           remote_url: 'https://github.io/brigade/fake_repo',
+           pushed_refs: 'refs/heads/master master'
+          )}
   subject { described_class.new(config, context) }
 
   context 'when git_lfs exits successfully' do


### PR DESCRIPTION
Upon running `overcommit --install`, the previously installed Git Lfs pre_push hook is moved aside to `.git/hooks/old-hooks`.  This hook adds support for GitLfs as a PrePush hook.

Do you think there needs to be more coverage in the specs?  I get nervous when I mock too much...