### PR TITLE
this commit fixes #311

### DIFF
--- a/lib/overcommit/utils/file_utils.rb
+++ b/lib/overcommit/utils/file_utils.rb
@@ -53,7 +53,7 @@ module Overcommit::Utils
 
       def win32_mklink_cmd(old_name, new_name)
         Overcommit::Subprocess.spawn(
-          %W[mklink #{win32_fix_pathsep(new_name)} #{win32_fix_pathsep(old_name)}]
+          %W[mklink /H #{win32_fix_pathsep(new_name)} #{win32_fix_pathsep(old_name)}]
         )
       end
 


### PR DESCRIPTION
As I don't think adding the symlinks manually at windows machines, I think using the '/H' option in the mklink command should fix the problem.