### PR TITLE
Add destructive_only flag to PrePush/ProtectedBranches hook

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -816,6 +816,7 @@ PrePush:
   ProtectedBranches:
     enabled: false
     description: 'Check for illegal pushes to protected branches'
+    destructive_only: true
     branches: ['master']
 
   RSpec:

--- a/lib/overcommit/hook/pre_push/protected_branches.rb
+++ b/lib/overcommit/hook/pre_push/protected_branches.rb
@@ -15,7 +15,7 @@ module Overcommit::Hook::PrePush
 
     def illegal_pushes
       @illegal_pushes ||= pushed_refs.select do |pushed_ref|
-        protected?(pushed_ref.remote_ref) && pushed_ref.destructive?
+        protected?(pushed_ref.remote_ref) && allow_non_destructive?(pushed_ref)
       end
     end
 
@@ -29,6 +29,14 @@ module Overcommit::Hook::PrePush
     def protected_branch_patterns
       @protected_branch_patterns ||= Array(config['branches']).
         concat(Array(config['branch_patterns']))
+    end
+
+    def allow_non_destructive?(ref)
+      if config['destructive_only'].nil? || config['destructive_only']
+        ref.destructive?
+      else
+        true
+      end
     end
   end
 end

--- a/lib/overcommit/hook/pre_push/protected_branches.rb
+++ b/lib/overcommit/hook/pre_push/protected_branches.rb
@@ -31,8 +31,12 @@ module Overcommit::Hook::PrePush
         concat(Array(config['branch_patterns']))
     end
 
+    def destructive_only?
+      config['destructive_only'].nil? || config['destructive_only']
+    end
+
     def allow_non_destructive?(ref)
-      if config['destructive_only'].nil? || config['destructive_only']
+      if destructive_only?
         ref.destructive?
       else
         true

--- a/spec/overcommit/hook/pre_push/protected_branches_spec.rb
+++ b/spec/overcommit/hook/pre_push/protected_branches_spec.rb
@@ -41,7 +41,8 @@ describe Overcommit::Hook::PrePush::ProtectedBranches do
     context 'when push is not destructive' do
       context 'and destructive_only set to false' do
         before do
-          subject.stub(:allow_non_destructive?).and_return(true)
+          pushed_ref.stub(:destructive?).and_return(false)
+          subject.stub(destructive_only?: false)
         end
 
         it { should fail_hook }
@@ -49,6 +50,7 @@ describe Overcommit::Hook::PrePush::ProtectedBranches do
 
       context 'and destructive_only set to true' do
         before do
+          subject.stub(destructive_only?: true)
           pushed_ref.stub(:destructive?).and_return(false)
         end
 

--- a/spec/overcommit/hook/pre_push/protected_branches_spec.rb
+++ b/spec/overcommit/hook/pre_push/protected_branches_spec.rb
@@ -39,19 +39,39 @@ describe Overcommit::Hook::PrePush::ProtectedBranches do
 
   shared_examples_for 'protected branch' do
     context 'when push is not destructive' do
-      before do
-        pushed_ref.stub(:destructive?).and_return(false)
+      context 'and destructive_only set to false' do
+        before do
+          subject.stub(:allow_non_destructive?).and_return(true)
+        end
+
+        it { should fail_hook }
       end
 
-      it { should pass }
+      context 'and destructive_only set to true' do
+        before do
+          pushed_ref.stub(:destructive?).and_return(false)
+        end
+
+        it { should pass }
+      end
     end
 
     context 'when push is destructive' do
-      before do
-        pushed_ref.stub(:destructive?).and_return(true)
+      context 'when destructive_only is set to true' do
+        before do
+          pushed_ref.stub(:destructive?).and_return(true)
+        end
+
+        it { should fail_hook }
       end
 
-      it { should fail_hook }
+      context 'when destructive_only is set to false' do
+        before do
+          subject.stub(:allow_non_destructive?).and_return(true)
+        end
+
+        it { should fail_hook }
+      end
     end
   end
 


### PR DESCRIPTION
Fixes: #354

Recently came across a situation where it would be beneficial to have a guard against standard git push to protected branches not just the destructive ones. 

The configuration for ProtectedBranch has a new option:

```yaml
PrePush:
  ProtectedBranches:
    enabled: true
    destructive_only: false # <== this is the new option
    branch_patterns:
      - 'master'
      - '*[A-Z]**/*'
```

When set to `destructive_only: false`, ProtectedBranches will check the branch name for all git push operations.
When omitted or set to `destructive_only: true`, ProtectedBranches only kicks in when the operation is destructive (force push, branch deletion).

I am not familiar with RSpec, I hope I got the examples right. Any feedback is welcomed! 