### PR TITLE
Make ctags only scan files git knows about

### DIFF
--- a/libexec/index-tags
+++ b/libexec/index-tags
@@ -8,7 +8,7 @@ set -e
 
 trap "rm -f $GIT_DIR/tags.$$" EXIT
 err_file=$GIT_DIR/ctags.err
-if ctags --tag-relative -Rf$GIT_DIR/tags.$$ --exclude=.git "$@" 2>${err_file}; then
+if git ls-files | ctags --tag-relative -L - -Rf$GIT_DIR/tags.$$ --exclude=.git "$@" 2>${err_file}; then
   mv $GIT_DIR/tags.$$ $GIT_DIR/tags
   [ -e ${err_file} ] && rm -f ${err_file}
 else


### PR DESCRIPTION
Set ctags to only scan files git knows about. This is useful because it prevents things like vendor or compiled assets from being scanned, speeding up the scan and reducing the size of the tagfile