### PR TITLE
Add *.ru matcher to rubocop hook files list

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -464,6 +464,7 @@ PreCommit:
       - '**/*.gemspec'
       - '**/*.rake'
       - '**/*.rb'
+      - '**/*.ru'
       - '**/Gemfile'
       - '**/Rakefile'
 


### PR DESCRIPTION
The files with `.ru` extension is often used to describe [Rackup config](https://github.com/rack/rack/wiki/(tutorial)-rackup-howto). Usually it's `config.ru`, but could be different. They contain regular ruby code, so they should be also checked by rubocop.