### PR TITLE
Fix TextWidth to allow for fixup!/squash! commits

### DIFF
--- a/lib/overcommit/hook/commit_msg/text_width.rb
+++ b/lib/overcommit/hook/commit_msg/text_width.rb
@@ -18,7 +18,9 @@ module Overcommit::Hook::CommitMsg
     private
 
     def find_errors_in_subject(subject)
-      max_subject_width = config['max_subject_width']
+      max_subject_width =
+        config['max_subject_width'] +
+        special_prefix_length(subject)
       return unless subject.length > max_subject_width
 
       @errors << "Please keep the subject <= #{max_subject_width} characters"
@@ -35,6 +37,10 @@ module Overcommit::Hook::CommitMsg
                     "#{max_body_width} characters"
         end
       end
+    end
+
+    def special_prefix_length(subject)
+      subject.match(/^(fixup|squash)! /) { |match| match[0].length } || 0
     end
   end
 end

--- a/spec/overcommit/hook/commit_msg/text_width_spec.rb
+++ b/spec/overcommit/hook/commit_msg/text_width_spec.rb
@@ -28,6 +28,18 @@ describe Overcommit::Hook::CommitMsg::TextWidth do
     it { should pass }
   end
 
+  context 'when subject starts with special "fixup!" and is longer than 60 characters' do
+    let(:commit_msg) { 'fixup! ' + 'A' * 60 }
+
+    it { should pass }
+  end
+
+  context 'when subject starts with special "squash!" and is longer than 60 characters' do
+    let(:commit_msg) { 'squash! ' + 'A' * 60 }
+
+    it { should pass }
+  end
+
   context 'when the subject is 60 characters followed by a newline' do
     let(:commit_msg) { <<-MSG }
       This is 60 characters, or 61 if the newline is counted


### PR DESCRIPTION
These are special commit message prefixes created by git commands, and
should not count towards the subject line length check.

This fixes #384 