### PR TITLE
Update JavaCheckstyle to categorize messages depending on type

### DIFF
--- a/lib/overcommit/hook/pre_commit/java_checkstyle.rb
+++ b/lib/overcommit/hook/pre_commit/java_checkstyle.rb
@@ -3,18 +3,25 @@ module Overcommit::Hook::PreCommit
   #
   # @see http://checkstyle.sourceforge.net/
   class JavaCheckstyle < Base
-    MESSAGE_REGEX = /^(\[[^\]]+\]\s+)?(?<file>(?:\w:)?[^:]+):(?<line>\d+)/
+    MESSAGE_REGEX = /^(?<type>\[[^\]]+\]\s+)?(?<file>(?:\w:)?[^:]+):(?<line>\d+)/
+
+    MESSAGE_TYPE_CATEGORIZER = lambda do |type|
+      # Type may be nil if checkstyle doesn't output a 'tag'
+      type = type || ""
+
+      type.include?('WARN') || type.include?('INFO') ? :warning : :error
+    end
 
     def run
       result = execute(command, args: applicable_files)
       output = result.stdout.chomp
-      return :pass if result.success?
 
       # example message:
       #   path/to/file.java:3:5: Error message
       extract_messages(
         output.split("\n").grep(MESSAGE_REGEX),
-        MESSAGE_REGEX
+        MESSAGE_REGEX,
+        MESSAGE_TYPE_CATEGORIZER
       )
     end
   end

--- a/lib/overcommit/hook/pre_commit/java_checkstyle.rb
+++ b/lib/overcommit/hook/pre_commit/java_checkstyle.rb
@@ -3,13 +3,10 @@ module Overcommit::Hook::PreCommit
   #
   # @see http://checkstyle.sourceforge.net/
   class JavaCheckstyle < Base
-    MESSAGE_REGEX = /^(?<type>\[[^\]]+\]\s+)?(?<file>(?:\w:)?[^:]+):(?<line>\d+)/
+    MESSAGE_REGEX = /^(\[(?<type>[^\]]+)\]\s+)?(?<file>(?:\w:)?[^:]+):(?<line>\d+)/
 
     MESSAGE_TYPE_CATEGORIZER = lambda do |type|
-      # Type may be nil if checkstyle doesn't output a 'tag'
-      type ||= ''
-
-      type.include?('WARN') || type.include?('INFO') ? :warning : :error
+      %w[WARN INFO].include?(type.to_s) ? :warning : :error
     end
 
     def run

--- a/lib/overcommit/hook/pre_commit/java_checkstyle.rb
+++ b/lib/overcommit/hook/pre_commit/java_checkstyle.rb
@@ -7,7 +7,7 @@ module Overcommit::Hook::PreCommit
 
     MESSAGE_TYPE_CATEGORIZER = lambda do |type|
       # Type may be nil if checkstyle doesn't output a 'tag'
-      type = type || ""
+      type ||= ''
 
       type.include?('WARN') || type.include?('INFO') ? :warning : :error
     end

--- a/spec/overcommit/hook/pre_commit/java_checkstyle_spec.rb
+++ b/spec/overcommit/hook/pre_commit/java_checkstyle_spec.rb
@@ -37,7 +37,7 @@ describe Overcommit::Hook::PreCommit::JavaCheckstyle do
       subject.stub(:execute).and_return(result)
     end
 
-    context 'and it reports an error' do
+    context 'and it reports a message with no severity tag' do
       before do
         result.stub(:stdout).and_return([
           'Starting audit...',
@@ -47,6 +47,42 @@ describe Overcommit::Hook::PreCommit::JavaCheckstyle do
       end
 
       it { should fail_hook }
+    end
+
+    context 'and it reports an error' do
+      before do
+        result.stub(:stdout).and_return([
+          'Starting audit...',
+          '[ERROR] file1.java:1: Missing a Javadoc comment.',
+          'Audit done.'
+        ].join("\n"))
+      end
+
+      it { should fail_hook }
+    end
+
+    context 'and it reports an warning' do
+      before do
+        result.stub(:stdout).and_return([
+          'Starting audit...',
+          '[WARN] file1.java:1: Missing a Javadoc comment.',
+          'Audit done.'
+        ].join("\n"))
+      end
+
+      it { should warn }
+    end
+
+    context 'and it reports an info message' do
+      before do
+        result.stub(:stdout).and_return([
+          'Starting audit...',
+          '[INFO] file1.java:1: Missing a Javadoc comment.',
+          'Audit done.'
+        ].join("\n"))
+      end
+
+      it { should warn }
     end
   end
 end

--- a/spec/overcommit/hook/pre_commit/java_checkstyle_spec.rb
+++ b/spec/overcommit/hook/pre_commit/java_checkstyle_spec.rb
@@ -29,7 +29,7 @@ describe Overcommit::Hook::PreCommit::JavaCheckstyle do
     end
   end
 
-  context 'when checkstyle exits unsucessfully' do
+  context 'when checkstyle exits unsuccessfully' do
     let(:result) { double('result') }
 
     before do


### PR DESCRIPTION
Checkstyle generates messages with `ERROR`, `WARN`, or `INFO` tags depending on their severity. Prior to this, all messages (irrespective of their tag) were treated as an error. With this change, messages with `WARN` and `INFO` tags will be handled as Overcommit warnings.

This fixes https://github.com/brigade/overcommit/issues/395