### PR TITLE
Add pre-push hook for running test-unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,7 @@ aborted.
 * [Minitest](lib/overcommit/hook/pre_push/minitest.rb)
 * [ProtectedBranches](lib/overcommit/hook/pre_push/protected_branches.rb)
 * [RSpec](lib/overcommit/hook/pre_push/r_spec.rb)
+* [TestUnit](lib/overcommit/hook/pre_push/test_unit.rb)
 
 ### PreRebase
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -838,6 +838,11 @@ PrePush:
     command: ['ruby', '-Ilib:test', '-rminitest', "-e 'exit! Minitest.run'"]
     include: 'test/**/*_test.rb'
 
+  TestUnit:
+    enabled: false
+    description: 'Run test-unit'
+    command: ['rake', 'test']
+
 # Hooks that run during `git rebase`, before any commits are rebased.
 # If a hook fails, the rebase is aborted.
 PreRebase:

--- a/config/default.yml
+++ b/config/default.yml
@@ -842,7 +842,6 @@ PrePush:
     enabled: false
     description: 'Run Test::Unit test suite'
     command: ['ruby', '-Ilib:test', '-rtest/unit', "-e 'exit! Test::Unit::AutoRunner.run'"]
-    include: 'test/**/*_test.rb'
 
 # Hooks that run during `git rebase`, before any commits are rebased.
 # If a hook fails, the rebase is aborted.

--- a/config/default.yml
+++ b/config/default.yml
@@ -840,8 +840,9 @@ PrePush:
 
   TestUnit:
     enabled: false
-    description: 'Run test-unit'
-    command: ['rake', 'test']
+    description: 'Run Test::Unit test suite'
+    command: ['ruby', '-Ilib:test', '-rtest/unit', "-e 'exit! Test::Unit::AutoRunner.run'"]
+    include: 'test/**/*_test.rb'
 
 # Hooks that run during `git rebase`, before any commits are rebased.
 # If a hook fails, the rebase is aborted.

--- a/lib/overcommit/hook/pre_push/test_unit.rb
+++ b/lib/overcommit/hook/pre_push/test_unit.rb
@@ -1,0 +1,14 @@
+module Overcommit::Hook::PrePush
+  # Runs `test-unit` test suite before push
+  #
+  # @see https://github.com/test-unit/test-unit
+  class TestUnit < Base
+    def run
+      result = execute(command)
+      return :pass if result.success?
+
+      output = result.stdout + result.stderr
+      [:fail, output]
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_push/test_unit_spec.rb
+++ b/spec/overcommit/hook/pre_push/test_unit_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PrePush::TestUnit do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context', all_files: ['test/foo_test.rb']) }
+
+  subject { described_class.new(config, context) }
+
+  context 'when test-unit exits successfully' do
+    let(:result) { double('result') }
+
+    before do
+      result.stub(:success?).and_return(true)
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should pass }
+  end
+
+  context 'when test-unit exits unsuccessfully' do
+    let(:result) { double('result') }
+
+    before do
+      result.stub(:success?).and_return(false)
+      subject.stub(:execute).and_return(result)
+    end
+
+    context 'with a runtime error' do
+      before do
+        result.stub(stdout: '', stderr: <<-EOS)
+          1) Error:
+          FooTest#test_: foo should bar. :
+          RuntimeError:
+          test/model/foo_test.rb:1:in `block (2 levels) in <class:FooTest>'
+        EOS
+      end
+
+      it { should fail_hook }
+    end
+  end
+end


### PR DESCRIPTION
This hook is to run [test-unit](https://github.com/test-unit/test-unit) like a RSpec or minitest before pushing remote repository.

I am not good at English, but I will always do my best.
If you have any question or advice, please don't hesitate to tell me. 🍻