### PR TITLE
Copy hook files instead of linking them

### DIFF
--- a/spec/integration/installing_overcommit_spec.rb
+++ b/spec/integration/installing_overcommit_spec.rb
@@ -9,12 +9,6 @@ describe 'installing Overcommit' do
     end
 
     it 'automatically installs Overcommit hooks for new repositories' do
-      if Overcommit::OS.windows?
-        # Symlinks in template-dir are not compatible with Windows.
-        # Windows users will need to manually install Overcommit for now.
-        skip 'Unix symlinks not compatible with Windows'
-      end
-
       Overcommit::Utils.supported_hook_types.each do |hook_type|
         hook_file = File.join('.git', 'hooks', hook_type)
         File.read(hook_file).should include 'OVERCOMMIT'
@@ -26,10 +20,10 @@ describe 'installing Overcommit' do
         `overcommit --install`
       end
 
-      it 'replaces the hooks with symlinks' do
+      it 'leaves the hooks intact' do
         Overcommit::Utils.supported_hook_types.each do |hook_type|
           hook_file = File.join('.git', 'hooks', hook_type)
-          Overcommit::Utils::FileUtils.symlink?(hook_file).should == true
+          File.read(hook_file).should include 'OVERCOMMIT'
         end
       end
     end

--- a/template-dir/hooks/commit-msg
+++ b/template-dir/hooks/commit-msg
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
-# in all of your git hooks being symlinked to this file, allowing the framework
+# in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.
 
 # Prevent a Ruby stack trace from appearing when we interrupt the hook.

--- a/template-dir/hooks/overcommit-hook
+++ b/template-dir/hooks/overcommit-hook
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
-# in all of your git hooks being symlinked to this file, allowing the framework
+# in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.
 
 # Prevent a Ruby stack trace from appearing when we interrupt the hook.

--- a/template-dir/hooks/post-checkout
+++ b/template-dir/hooks/post-checkout
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
-# in all of your git hooks being symlinked to this file, allowing the framework
+# in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.
 
 # Prevent a Ruby stack trace from appearing when we interrupt the hook.

--- a/template-dir/hooks/post-commit
+++ b/template-dir/hooks/post-commit
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
-# in all of your git hooks being symlinked to this file, allowing the framework
+# in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.
 
 # Prevent a Ruby stack trace from appearing when we interrupt the hook.

--- a/template-dir/hooks/post-merge
+++ b/template-dir/hooks/post-merge
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
-# in all of your git hooks being symlinked to this file, allowing the framework
+# in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.
 
 # Prevent a Ruby stack trace from appearing when we interrupt the hook.

--- a/template-dir/hooks/post-rewrite
+++ b/template-dir/hooks/post-rewrite
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
-# in all of your git hooks being symlinked to this file, allowing the framework
+# in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.
 
 # Prevent a Ruby stack trace from appearing when we interrupt the hook.

--- a/template-dir/hooks/pre-commit
+++ b/template-dir/hooks/pre-commit
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
-# in all of your git hooks being symlinked to this file, allowing the framework
+# in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.
 
 # Prevent a Ruby stack trace from appearing when we interrupt the hook.

--- a/template-dir/hooks/pre-push
+++ b/template-dir/hooks/pre-push
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
-# in all of your git hooks being symlinked to this file, allowing the framework
+# in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.
 
 # Prevent a Ruby stack trace from appearing when we interrupt the hook.

--- a/template-dir/hooks/pre-rebase
+++ b/template-dir/hooks/pre-rebase
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
-# in all of your git hooks being symlinked to this file, allowing the framework
+# in all of your git hooks being copied from this file, allowing the framework
 # to manage your hooks for you.
 
 # Prevent a Ruby stack trace from appearing when we interrupt the hook.


### PR DESCRIPTION
As explained in #400, creating symlinks on Windows with `mklink` requires admin privileges, which makes Overcommit unusable for non-admin users. Our handling of symlinks on Windows is already brittle enough, so we may as well switch to copying.

We could symlink on *nix and copy on Windows, but that would unnecessarily complicate the code and specs, and I think it's better to keep behavior consistent across platforms anyway.