### PR TITLE
Run Brakeman on whole project

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -154,7 +154,7 @@ PreCommit:
     enabled: false
     description: 'Check for security vulnerabilities'
     required_executable: 'brakeman'
-    flags: ['--exit-on-warn', '--quiet', '--summary', '--only-files']
+    flags: ['--exit-on-warn', '--quiet', '--summary']
     install_command: 'gem install brakeman'
     include:
       - '**/*.rb'

--- a/lib/overcommit/hook/pre_commit/brakeman.rb
+++ b/lib/overcommit/hook/pre_commit/brakeman.rb
@@ -1,10 +1,10 @@
 module Overcommit::Hook::PreCommit
-  # Runs `brakeman` against any modified Ruby/Rails files.
+  # Runs `brakeman` whenever Ruby/Rails files change.
   #
   # @see http://brakemanscanner.org/
   class Brakeman < Base
     def run
-      result = execute(command + [applicable_files.join(',')])
+      result = execute(command)
       return :pass if result.success?
 
       [:fail, result.stdout]


### PR DESCRIPTION
But only when a Ruby file changes.

This is because `--only-files` is dangerous: even if you include every
single Ruby file (as with `overcommit -r`) it doesn't catch
everything. We can either expand it to include all necessary files
(I don't know which they are, and it's brittle as it might change), or
choose the safer option: run Brakeman on the entire project, which for
lots of projects should be pretty fast anyway.