### PR TITLE
Add commit-msg hook for commitplease

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -114,6 +114,12 @@ CommitMsg:
     enabled: true
     description: 'Check for trailing periods in subject'
 
+  Commitplease:
+    enabled: false
+    description: 'Analyze with Commitplease'
+    required_executable: './node_modules/.bin/commitplease'
+    install_command: 'npm install --save-dev commitplease'
+
 # Hooks that are run after `git commit` is executed, before the commit message
 # editor is displayed. These hooks are ideal for syntax checkers, linters, and
 # other checks that you want to run before you allow a commit object to be

--- a/lib/overcommit/hook/commit_msg/commitplease.rb
+++ b/lib/overcommit/hook/commit_msg/commitplease.rb
@@ -1,0 +1,12 @@
+module Overcommit::Hook::CommitMsg
+  # Check that a commit message conforms to a certain style
+  class Commitplease < Base
+    def run
+      result = execute(command)
+      output = result.stderr
+      return :pass if result.success? && output.empty?
+
+      [:fail, output]
+    end
+  end
+end


### PR DESCRIPTION
[Commitplease][1] is an npm module that uses commit-msg hook to check that a commit message follows a certain style guide.

I have described how [it works with overcommit][2] and would be grateful if you could sanity-check that :)

Closes #405
Refs jzaefferer/commitplease#72

[1]: https://github.com/jzaefferer/commitplease
[2]: https://github.com/jzaefferer/commitplease/issues/72#issuecomment-235827024