### PR TITLE
Add Credo pre-commit hook to check Elixir files

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -211,6 +211,15 @@ PreCommit:
     install_command: 'npm install -g coffeelint'
     include: '**/*.coffee'
 
+  Credo:
+    enabled: false
+    description: 'Analyze with credo'
+    required_executable: 'mix'
+    flags: ['credo', '--all', '--strict', '--format', 'flycheck']
+    include:
+      - '**/*.ex'
+      - '**/*.exs'
+
   CssLint:
     enabled: false
     description: 'Analyze with csslint'

--- a/lib/overcommit/hook/pre_commit/credo.rb
+++ b/lib/overcommit/hook/pre_commit/credo.rb
@@ -1,0 +1,25 @@
+module Overcommit::Hook::PreCommit
+  # Runs `credo` against any modified ex files.
+  #
+  # @see https://github.com/rrrene/credo
+  class Credo < Base
+    # example message:
+    # lib/file1.ex:1:11: R: Modules should have a @moduledoc tag.
+    # lib/file2.ex:12:81: R: Line is too long (max is 80, was 81).
+
+    def run
+      result = execute command
+      return :pass if result.success?
+
+      result.stdout.split("\n").map(&:strip).reject(&:empty?).
+        map { |error| message(error) }
+    end
+
+    private
+
+    def message(error)
+      file, line = error.split(':')
+      Overcommit::Hook::Message.new(:error, file, Integer(line), error)
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_commit/credo_spec.rb
+++ b/spec/overcommit/hook/pre_commit/credo_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::Credo do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  before do
+    subject.stub(:applicable_files).and_return(%w[file1.ex file2.exs])
+  end
+
+  context 'when credo exits successfully' do
+    before do
+      result = double('result')
+      result.stub(:success?).and_return(true)
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should pass }
+  end
+
+  context 'when credo exits unsucessfully' do
+    let(:result) { double('result') }
+
+    before do
+      result.stub(:success?).and_return(false)
+      subject.stub(:execute).and_return(result)
+    end
+
+    context 'and it reports an error' do
+      before do
+        result.stub(:stdout).and_return([
+          'file1.ex:1:11: R: Modules should have a @moduledoc tag.',
+          'file2.ex:1:11: R: Modules should have a @moduledoc tag.'
+        ].join("\n"))
+        result.stub(:stderr).and_return('')
+      end
+
+      it { should fail_hook }
+    end
+  end
+end


### PR DESCRIPTION
Credo is a static code analysis tool for Elixir.

Credo's source code is available at https://github.com/rrrene/credo

This pre-commit hook executes credo and reports errors.