### PR TITLE
Added pre-commit hook to check for Windows line endings

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -592,7 +592,8 @@ PreCommit:
   LineEndings:
     description: 'Check line endings'
     enabled: false
-    representation: 'unix'
+    eol: 'lf'
+    # eol: 'crlf'
 
   XmlLint:
     enabled: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -592,8 +592,7 @@ PreCommit:
   LineEndings:
     description: 'Check line endings'
     enabled: false
-    eol: 'lf'
-    # eol: 'crlf'
+    eol: "\n"
 
   XmlLint:
     enabled: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -589,6 +589,11 @@ PreCommit:
     include:
       - '**/*.html'
 
+  LineEndings:
+    description: 'Check line endings'
+    enabled: false
+    representation: 'unix'
+
   XmlLint:
     enabled: false
     description: 'Analyze with xmllint'

--- a/lib/overcommit/hook/pre_commit/line_endings.rb
+++ b/lib/overcommit/hook/pre_commit/line_endings.rb
@@ -33,6 +33,7 @@ module Overcommit::Hook::PreCommit
 
       result.stdout.split("\0").map do |file_info|
         i, _w, _attr, path = file_info.split
+        next if i == 'l/-text' # ignore binary files
         next if i == "l/#{eol}"
         path
       end.compact

--- a/lib/overcommit/hook/pre_commit/line_endings.rb
+++ b/lib/overcommit/hook/pre_commit/line_endings.rb
@@ -4,7 +4,7 @@ module Overcommit::Hook::PreCommit
     def run
       messages = []
 
-      applicable_files.map do |file_name|
+      text_files.map do |file_name|
         file = File.open(file_name)
         file.each_line do |line|
           next if unix? && line =~ /\A((?!\r).)*\n\z/
@@ -24,12 +24,19 @@ module Overcommit::Hook::PreCommit
 
     private
 
+    def text_files
+      result = execute(%w[git grep -zIl \'\' --], args: applicable_files)
+      raise 'Unable to access git tree' unless result.success?
+
+      result.stdout.split("\0")
+    end
+
     def unix?
-      config['representation'] == 'unix'
+      config['eol'] == 'lf'
     end
 
     def windows?
-      config['representation'] == 'windows'
+      config['eol'] == 'crlf'
     end
   end
 end

--- a/lib/overcommit/hook/pre_commit/line_endings.rb
+++ b/lib/overcommit/hook/pre_commit/line_endings.rb
@@ -1,0 +1,35 @@
+module Overcommit::Hook::PreCommit
+  # Checks for line endings in files.
+  class LineEndings < Base
+    def run
+      messages = []
+
+      applicable_files.map do |file_name|
+        file = File.open(file_name)
+        file.each_line do |line|
+          next if unix? && !line.end_with?("\r\n")
+          next if windows? && line.end_with?("\r\n")
+
+          messages << Overcommit::Hook::Message.new(
+            :error,
+            file_name,
+            file.lineno,
+            "#{file_name}:#{file.lineno}:#{line.inspect}"
+          )
+        end
+      end
+
+      messages
+    end
+
+    private
+
+    def unix?
+      config['representation'] == 'unix'
+    end
+
+    def windows?
+      config['representation'] == 'windows'
+    end
+  end
+end

--- a/lib/overcommit/hook/pre_commit/line_endings.rb
+++ b/lib/overcommit/hook/pre_commit/line_endings.rb
@@ -7,8 +7,8 @@ module Overcommit::Hook::PreCommit
       applicable_files.map do |file_name|
         file = File.open(file_name)
         file.each_line do |line|
-          next if unix? && !line.end_with?("\r\n")
-          next if windows? && line.end_with?("\r\n")
+          next if unix? && line =~ /\A((?!\r).)*\n\z/
+          next if windows? && line =~ /\A.*\r\n\z/
 
           messages << Overcommit::Hook::Message.new(
             :error,

--- a/spec/overcommit/hook/pre_commit/line_endings_spec.rb
+++ b/spec/overcommit/hook/pre_commit/line_endings_spec.rb
@@ -14,7 +14,7 @@ describe Overcommit::Hook::PreCommit::LineEndings do
   end
   let(:context) { double('context') }
   subject { described_class.new(config, context) }
-  let(:eol) { 'lf' }
+  let(:eol) { "\n" }
   let(:staged_file) { 'filename.txt' }
 
   before do
@@ -29,30 +29,30 @@ describe Overcommit::Hook::PreCommit::LineEndings do
     end
   end
 
-  context 'when enforcing lf' do
-    context 'when file contains crlf line endings' do
+  context 'when enforcing \n' do
+    context 'when file contains \r\n line endings' do
       let(:contents) { "CR-LF\r\nline\r\nendings\r\n" }
 
       it { should fail_hook }
     end
 
-    context 'when file contains lf endings' do
+    context 'when file contains \n endings' do
       let(:contents) { "LF\nline\nendings\n" }
 
       it { should pass }
     end
   end
 
-  context 'when enforcing crlf' do
-    let(:eol) { 'crlf' }
+  context 'when enforcing \r\n' do
+    let(:eol) { "\r\n" }
 
-    context 'when file contains crlf line endings' do
+    context 'when file contains \r\n line endings' do
       let(:contents) { "CR-LF\r\nline\r\nendings\r\n" }
 
       it { should pass }
     end
 
-    context 'when file contains lf line endings' do
+    context 'when file contains \n line endings' do
       let(:contents) { "LF\nline\nendings\n" }
 
       it { should fail_hook }

--- a/spec/overcommit/hook/pre_commit/line_endings_spec.rb
+++ b/spec/overcommit/hook/pre_commit/line_endings_spec.rb
@@ -6,7 +6,7 @@ describe Overcommit::Hook::PreCommit::LineEndings do
       Overcommit::Configuration.new(
         'PreCommit' => {
           'LineEndings' => {
-            'representation' => representation
+            'eol' => eol
           }
         }
       )
@@ -14,7 +14,7 @@ describe Overcommit::Hook::PreCommit::LineEndings do
   end
   let(:context) { double('context') }
   subject { described_class.new(config, context) }
-  let(:representation) { 'unix' }
+  let(:eol) { 'lf' }
   let(:staged_file) { 'filename.txt' }
 
   before do
@@ -29,30 +29,30 @@ describe Overcommit::Hook::PreCommit::LineEndings do
     end
   end
 
-  context 'when enforcing unix representation' do
-    context 'when file contains windows line endings' do
+  context 'when enforcing lf' do
+    context 'when file contains crlf line endings' do
       let(:contents) { "CR-LF\r\nline\r\nendings\r\n" }
 
       it { should fail_hook }
     end
 
-    context 'when file contains unix line endings' do
+    context 'when file contains lf endings' do
       let(:contents) { "LF\nline\nendings\n" }
 
       it { should pass }
     end
   end
 
-  context 'when enforcing windows representation' do
-    let(:representation) { 'windows' }
+  context 'when enforcing crlf' do
+    let(:eol) { 'crlf' }
 
-    context 'when file contains windows line endings' do
+    context 'when file contains crlf line endings' do
       let(:contents) { "CR-LF\r\nline\r\nendings\r\n" }
 
       it { should pass }
     end
 
-    context 'when file contains unix line endings' do
+    context 'when file contains lf line endings' do
       let(:contents) { "LF\nline\nendings\n" }
 
       it { should fail_hook }

--- a/spec/overcommit/hook/pre_commit/line_endings_spec.rb
+++ b/spec/overcommit/hook/pre_commit/line_endings_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::LineEndings do
+  let(:config) do
+    Overcommit::ConfigurationLoader.default_configuration.merge(
+      Overcommit::Configuration.new(
+        'PreCommit' => {
+          'LineEndings' => {
+            'representation' => representation
+          }
+        }
+      )
+    )
+  end
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+  let(:representation) { 'unix' }
+  let(:staged_file) { 'filename.txt' }
+
+  before do
+    subject.stub(:applicable_files).and_return([staged_file])
+  end
+
+  around do |example|
+    repo do
+      File.open(staged_file, 'w') { |f| f.write(contents) }
+      `git add #{staged_file}`
+      example.run
+    end
+  end
+
+  context 'when enforcing unix representation' do
+    context 'when file contains windows line endings' do
+      let(:contents) { "CR-LF\r\nline\r\nendings\r\n" }
+
+      it { should fail_hook }
+    end
+
+    context 'when file contains unix line endings' do
+      let(:contents) { "LF\nline\nendings\n" }
+
+      it { should pass }
+    end
+  end
+
+  context 'when enforcing windows representation' do
+    let(:representation) { 'windows' }
+
+    context 'when file contains windows line endings' do
+      let(:contents) { "CR-LF\r\nline\r\nendings\r\n" }
+
+      it { should pass }
+    end
+
+    context 'when file contains unix line endings' do
+      let(:contents) { "LF\nline\nendings\n" }
+
+      it { should fail_hook }
+    end
+  end
+end


### PR DESCRIPTION
Proposal to add a hook to verify the used line endings. This could also be extend to be a more generic line endings check, for example for projects who insist on CRLF instead of LF.