### PR TITLE
Return from protected? method unless find regex pattern

### DIFF
--- a/lib/overcommit/hook/pre_push/protected_branches.rb
+++ b/lib/overcommit/hook/pre_push/protected_branches.rb
@@ -20,7 +20,7 @@ module Overcommit::Hook::PrePush
     end
 
     def protected?(remote_ref)
-      ref_name = remote_ref[%r{refs/heads/(.*)}, 1]
+      return unless ref_name = remote_ref[%r{refs/heads/(.*)}, 1]
       protected_branch_patterns.any? do |pattern|
         File.fnmatch(pattern, ref_name)
       end


### PR DESCRIPTION
This allows git push --tags to work.  Normally it can't find a ref_name