### PR TITLE
#419 - Added missing TSLint reference in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ issue](https://github.com/brigade/overcommit/issues/238) for more details.
 * [SlimLint](lib/overcommit/hook/pre_commit/slim_lint.rb)
 * [Sqlint](lib/overcommit/hook/pre_commit/sqlint.rb)
 * [Standard](lib/overcommit/hook/pre_commit/standard.rb)
+* [TsLint](lib/overcommit/hook/pre_commit/ts_lint.rb)
 * [TrailingWhitespace](lib/overcommit/hook/pre_commit/trailing_whitespace.rb)
 * [TravisLint](lib/overcommit/hook/pre_commit/travis_lint.rb)
 * [Vint](lib/overcommit/hook/pre_commit/vint.rb)


### PR DESCRIPTION
Forgot about this in the [previous](https://github.com/brigade/overcommit/pull/421) PR.