### PR TITLE
Fix RailsSchemaUpToDate for new Rails projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Add [`Brakeman`](http://brakemanscanner.org/) pre-push hook
 * Add [`TSLint`](http://palantir.github.io/tslint/) pre-commit hook
 * Validate that hook `env` environment configurations have valid names/values
+* Fix a false negative reported by RailsSchemaUpToDate for newly-created Rails
+  projects that don't yet have any migrations
 
 ## 0.35.0
 

--- a/lib/overcommit/hook/pre_commit/rails_schema_up_to_date.rb
+++ b/lib/overcommit/hook/pre_commit/rails_schema_up_to_date.rb
@@ -1,10 +1,13 @@
 module Overcommit::Hook::PreCommit
-  # Check to see whether the schema file is in line with the migrations
+  # Check to see whether the schema file is in line with the migrations. When a
+  # schema file is present but a migration file is not, this is usually a
+  # failure. The exception is if the schema is at version 0 (i.e before any
+  # migrations have been run). In this case it is OK if there are no migrations.
   class RailsSchemaUpToDate < Base
     def run # rubocop:disable CyclomaticComplexity, PerceivedComplexity
       if migration_files.any? && schema_files.none?
         return :fail, "It looks like you're adding a migration, but did not update the schema file"
-      elsif migration_files.none? && schema_files.any?
+      elsif migration_files.none? && schema_files.any? && non_zero_schema_version?
         return :fail, "You're trying to change the schema without adding a migration file"
       elsif migration_files.any? && schema_files.any?
         # Get the latest version from the migration filename. Use
@@ -15,7 +18,6 @@ module Overcommit::Hook::PreCommit
           File.basename(file)[/\d+/]
         end.sort.last
 
-        schema     = schema_files.map { |file| File.read(file) }.join
         up_to_date = schema.include?(latest_version)
 
         unless up_to_date
@@ -40,6 +42,14 @@ module Overcommit::Hook::PreCommit
       @schema_files ||= applicable_files.select do |file|
         file.match %r{db/schema\.rb|db/structure.*\.sql}
       end
+    end
+
+    def schema
+      @schema ||= schema_files.map { |file| File.read(file) }.join
+    end
+
+    def non_zero_schema_version?
+      schema =~ /\d{14}/
     end
   end
 end

--- a/spec/overcommit/hook/pre_commit/rails_schema_up_to_date_spec.rb
+++ b/spec/overcommit/hook/pre_commit/rails_schema_up_to_date_spec.rb
@@ -44,7 +44,7 @@ describe Overcommit::Hook::PreCommit::RailsSchemaUpToDate do
     around do |example|
       repo do
         FileUtils.mkdir_p('db/migrate')
-        File.open(ruby_schema_file, 'w') { |f| f.write('schema') }
+        File.open(ruby_schema_file, 'w') { |f| f.write('version: 20160904205635') }
         `git add #{ruby_schema_file}`
         example.run
       end
@@ -61,7 +61,7 @@ describe Overcommit::Hook::PreCommit::RailsSchemaUpToDate do
     around do |example|
       repo do
         FileUtils.mkdir_p('db/migrate')
-        File.open(sql_schema_file, 'w') { |f| f.write('schema') }
+        File.open(sql_schema_file, 'w') { |f| f.write("VALUES ('20151214213046')") }
         `git add #{sql_schema_file}`
         example.run
       end
@@ -192,5 +192,24 @@ describe Overcommit::Hook::PreCommit::RailsSchemaUpToDate do
     end
 
     it { should fail_hook }
+  end
+
+  context 'when the schema file is at version 0 and there are no migrations' do
+    before do
+      subject.stub(:applicable_files).and_return([ruby_schema_file])
+    end
+
+    around do |example|
+      repo do
+        FileUtils.mkdir_p('db')
+
+        File.open(ruby_schema_file, 'w') { |f| f.write('version: 0') }
+        `git add #{ruby_schema_file}`
+
+        example.run
+      end
+    end
+
+    it { should pass }
   end
 end


### PR DESCRIPTION
A new Rails app has no migration files, but if `db:migrate` has been run, then it will have a `schema.rb` with version 0. This would result in the failure "You're trying to change the schema without adding a migration file", which is a false negative.

Fix this by adding a `non_zero_schema_version?` test such that a schema at version 0 is allowed to be committed without any migrations present.

I've included a test and CHANGELOG entry. Fixes #417