### PR TITLE
Skip Overcommit builds for JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ before_script:
 
 script:
   - bundle exec rspec
+  # Skip Overcommit on JRuby since it's unstable and doesn't actually test Overcommit
+  - '[[ $TRAVIS_RUBY_VERSION =~ ^jruby ]] && exit || true'
   - bundle exec overcommit --sign
   - bundle exec overcommit --sign pre-commit
   - bundle exec overcommit --run


### PR DESCRIPTION
Our Travis builds fail for JRuby with a mysterious:

```
  Check Travis CI configuration......................[TravisLint] FAILED
  Hook raised unexpected error
  Cannot run program "travis" (in directory "/home/travis/build/brigade/overcommit"):
  error=2, No such file or directory
```

...and similarly for other executables, e.g. `rubocop`.

This appears to be specific to the JRuby runtime. Since we don't care if
Overcommit runs work on JRuby, skip Overcommit for JRuby builds.