### PR TITLE
Add licence header enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## master
 
 * Add [`YAMLLint`](https://github.com/adrienverge/yamllint) pre-commit hook
+* Add `LicenceHeader` pre-commit enforcement to ensure open source projects
+  contain proper licence comments.
 
 ## 0.36.0
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -371,6 +371,7 @@ PreCommit:
     enabled: false
     include: '**/*.*'
     licence_file: 'LICENSE.txt'
+    description: 'Check source files for licence headers'
 
   LocalPathsInGemfile:
     enabled: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -369,7 +369,6 @@ PreCommit:
 
   LicenceHeader:
     enabled: false
-    include: '**/*.*'
     licence_file: 'LICENSE.txt'
     description: 'Check source files for licence headers'
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -367,6 +367,11 @@ PreCommit:
     install_command: 'gem install json'
     include: '**/*.json'
 
+  LicenceHeader:
+    enabled: false
+    include: '**/*.*'
+    licence_file: 'LICENSE.txt'
+
   LocalPathsInGemfile:
     enabled: false
     description: 'Check for local paths in Gemfile'

--- a/lib/overcommit/hook/pre_commit/licence_header.rb
+++ b/lib/overcommit/hook/pre_commit/licence_header.rb
@@ -9,7 +9,7 @@ module Overcommit::Hook::PreCommit
       end
 
       messages = applicable_files.map do |file|
-        check_file(file, license_contents)
+        check_file(file, licence_contents)
       end.compact
 
       return :fail, messages.join("\n") if messages.any?

--- a/lib/overcommit/hook/pre_commit/licence_header.rb
+++ b/lib/overcommit/hook/pre_commit/licence_header.rb
@@ -1,0 +1,47 @@
+module Overcommit::Hook::PreCommit
+  # Checks for licence headers in source files
+  class LicenceHeader < Base
+    def run
+      begin
+        licence_contents = licence_lines
+      rescue Errno::ENOENT
+        return :fail, "Unable to load licence file #{licence_file}"
+      end
+
+      applicable_files.each do |file|
+        message = check_file(file, licence_contents)
+        if message
+          return :fail, message
+        end
+      end
+
+      :pass
+    end
+
+    def check_file(file, licence_contents)
+      File.readlines(file).each_with_index do |l, i|
+        if i >= licence_contents.length
+          break
+        end
+
+        l.chomp!
+        unless l.end_with?(licence_contents[i])
+          message = "#{file} missing header contents from line #{i} of "\
+                    "#{licence_file}: #{licence_contents[i]}"
+          return message
+        end
+      end
+    end
+
+    def licence_file
+      config['licence_file']
+    end
+
+    def licence_lines
+      @licence_regex ||= begin
+        file_root = Overcommit::Utils.convert_glob_to_absolute(licence_file)
+        File.read(file_root).split("\n")
+      end
+    end
+  end
+end

--- a/lib/overcommit/hook/pre_commit/licence_header.rb
+++ b/lib/overcommit/hook/pre_commit/licence_header.rb
@@ -8,12 +8,11 @@ module Overcommit::Hook::PreCommit
         return :fail, "Unable to load licence file #{licence_file}"
       end
 
-      applicable_files.each do |file|
-        message = check_file(file, licence_contents)
-        if message
-          return :fail, message
-        end
-      end
+      messages = applicable_files.map do |file|
+        check_file(file, license_contents)
+      end.compact
+
+      return :fail, messages.join("\n") if messages.any?
 
       :pass
     end

--- a/spec/overcommit/hook/pre_commit/licence_header_spec.rb
+++ b/spec/overcommit/hook/pre_commit/licence_header_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::LicenceHeader do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  context 'when licence file is missing' do
+    before do
+      subject.stub(:licence_lines).and_raise(Errno::ENOENT)
+    end
+
+    it { should fail_hook }
+  end
+
+  context 'with headers in all applicable files' do
+    let(:licence) do
+      ['Hello World', 'Copyleft 2017']
+    end
+
+    before do
+      subject.stub(:applicable_files).and_return(%w[main.go])
+      subject.stub(:licence_lines).and_return(licence)
+      subject.stub(:check_file).and_return(nil)
+    end
+
+    it { should pass }
+  end
+end

--- a/spec/overcommit/hook/pre_commit/licence_header_spec.rb
+++ b/spec/overcommit/hook/pre_commit/licence_header_spec.rb
@@ -5,25 +5,43 @@ describe Overcommit::Hook::PreCommit::LicenceHeader do
   let(:context) { double('context') }
   subject { described_class.new(config, context) }
 
-  context 'when licence file is missing' do
-    before do
-      subject.stub(:licence_lines).and_raise(Errno::ENOENT)
+  around do |example|
+    repo do
+      example.run
     end
+  end
 
+  context 'when license file is missing' do
     it { should fail_hook }
   end
 
-  context 'with headers in all applicable files' do
-    let(:licence) do
-      ['Hello World', 'Copyleft 2017']
-    end
+  context 'when license file exists' do
+    let(:license_contents) { <<-LICENSE }
+    Look at me
+    I'm a license
+    LICENSE
+
+    let(:file) { 'some-file.txt' }
 
     before do
-      subject.stub(:applicable_files).and_return(%w[main.go])
-      subject.stub(:licence_lines).and_return(licence)
-      subject.stub(:check_file).and_return(nil)
+      File.open('LICENSE.txt', 'w') { |f| f.write(license_contents) }
+      subject.stub(:applicable_files).and_return([file])
     end
 
-    it { should pass }
+    context 'when all files contain the license header' do
+      before do
+        File.open(file, 'w') { |f| f.puts(license_contents); f.write('And some text') }
+      end
+
+      it { should pass }
+    end
+
+    context 'when all files contain the license header' do
+      before do
+        File.open(file, 'w') { |f| f.write('Some text without a license') }
+      end
+
+      it { should fail_hook }
+    end
   end
 end

--- a/spec/overcommit/hook/pre_commit/licence_header_spec.rb
+++ b/spec/overcommit/hook/pre_commit/licence_header_spec.rb
@@ -30,13 +30,18 @@ describe Overcommit::Hook::PreCommit::LicenceHeader do
 
     context 'when all files contain the license header' do
       before do
-        File.open(file, 'w') { |f| f.puts(license_contents); f.write('And some text') }
+        File.open(file, 'w') do |f|
+          license_contents.split("\n").each do |line|
+            f.puts("// #{line}")
+          end
+          f.write('And some text')
+        end
       end
 
       it { should pass }
     end
 
-    context 'when all files contain the license header' do
+    context 'when a file is missing a licence header' do
       before do
         File.open(file, 'w') { |f| f.write('Some text without a license') }
       end


### PR DESCRIPTION
Fixes #438

Man, my Ruby is rusty. I don't know the best way to test this. I've
tried it out on my project manually.

Tested manually:

```
Updating signature for configuration file...
Running pre-commit hooks
Check YAML syntax........................................[YamlSyntax] OK
Check for trailing whitespace....................[TrailingWhitespace] OK
Validate JSON syntax.....................................[JsonSyntax] OK
Run LicenceHeader.....................................[LicenceHeader] FAILED
/Users/aiden/src/go/src/github.com/uber-go/uberfx/uberfx.go missing header contents from line 18 of LICENSE.txt: THE SOFTWARE.
```