### PR TITLE
Keep net-http-persistent below 3.0 for Ruby 2.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 cache: bundler
 
 rvm:
+  - 2.0
   - 2.1
   - 2.2
   - 2.3.0

--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,6 @@ gem 'coveralls'
 
 # Pin RuboCop for Travis builds.
 gem 'rubocop', '0.43.0'
+
+# Prevent errors for Ruby < 2.1
+gem 'net-http-persistent', '~> 2.7'

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ writing any Ruby code.
 
 This project aims to support the following Ruby runtimes on both \*nix and Windows:
 
-* MRI 2.1+
+* MRI 2.x
 * JRuby 9+
 
 ## Limitations

--- a/overcommit.gemspec
+++ b/overcommit.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
                             Dir['libexec/**/*'] +
                             Dir['template-dir/**/*']
 
-  s.required_ruby_version = '>= 2.1'
+  s.required_ruby_version = '>= 2'
 
   s.add_dependency             'childprocess', '~> 0.5.8'
   s.add_dependency             'iniparse', '~> 1.4'


### PR DESCRIPTION
No need to drop support for 2.0 altogether, we just need to pin `net-http-persistent` below `3.0`.