### PR TITLE
Moved `Commitplease` hook from `CommitMsg` to `PostCommit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+* Moved `CommitPlease` from `CommitMsg` to `PostCommit` hook
 * Add `skip_file_checkout` hook setting for `PostCheckout` hooks
 
 ## 0.37.0

--- a/README.md
+++ b/README.md
@@ -391,7 +391,6 @@ a task ID is included for tracking purposes, or ensuring your commit messages
 follow [proper formatting guidelines](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 
 * [`*`CapitalizedSubject](lib/overcommit/hook/commit_msg/capitalized_subject.rb)
-* [Commitplease](lib/overcommit/hook/commit_msg/commitplease.rb)
 * [`*`EmptyMessage](lib/overcommit/hook/commit_msg/empty_message.rb)
 * [GerritChangeId](lib/overcommit/hook/commit_msg/gerrit_change_id.rb)
 * [HardTabs](lib/overcommit/hook/commit_msg/hard_tabs.rb)
@@ -421,6 +420,7 @@ however, it can be used to alert the user to some issue.
 
 * [BowerInstall](lib/overcommit/hook/post_commit/bower_install.rb)
 * [BundleInstall](lib/overcommit/hook/post_commit/bundle_install.rb)
+* [Commitplease](lib/overcommit/hook/post_commit/commitplease.rb)
 * [GitGuilt](lib/overcommit/hook/post_commit/git_guilt.rb)
 * [IndexTags](lib/overcommit/hook/post_commit/index_tags.rb)
 * [NpmInstall](lib/overcommit/hook/post_commit/npm_install.rb)

--- a/config/default.yml
+++ b/config/default.yml
@@ -114,12 +114,6 @@ CommitMsg:
     enabled: true
     description: 'Check for trailing periods in subject'
 
-  Commitplease:
-    enabled: false
-    description: 'Analyze with Commitplease'
-    required_executable: './node_modules/.bin/commitplease'
-    install_command: 'npm install --save-dev commitplease'
-
 # Hooks that are run after `git commit` is executed, before the commit message
 # editor is displayed. These hooks are ideal for syntax checkers, linters, and
 # other checks that you want to run before you allow a commit object to be
@@ -746,6 +740,13 @@ PostCommit:
       - 'Gemfile'
       - 'Gemfile.lock'
       - '*.gemspec'
+
+  Commitplease:
+    enabled: false
+    description: 'Analyze with Commitplease'
+    required_executable: './node_modules/.bin/commitplease'
+    install_command: 'npm install --save-dev commitplease'
+    flags: ['-1']
 
   GitGuilt:
     enabled: false

--- a/lib/overcommit/hook/post_commit/commitplease.rb
+++ b/lib/overcommit/hook/post_commit/commitplease.rb
@@ -1,4 +1,4 @@
-module Overcommit::Hook::CommitMsg
+module Overcommit::Hook::PostCommit
   # Check that a commit message conforms to a certain style
   #
   # @see https://www.npmjs.com/package/commitplease

--- a/spec/overcommit/hook/post_commit/commitplease_spec.rb
+++ b/spec/overcommit/hook/post_commit/commitplease_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PostCommit::Commitplease do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  let(:result) { double('result') }
+
+  before do
+    subject.stub(:execute).and_return(result)
+  end
+
+  context 'when commitplease exits successfully' do
+    before do
+      result.stub(:success?).and_return(true)
+      result.stub(:stderr).and_return('')
+    end
+
+    it { should pass }
+  end
+
+  context 'when commitplease exits unsuccessfully' do
+    before do
+      result.stub(success?: false, stderr: normalize_indent(<<-OUT))
+        - First line must be <type>(<scope>): <subject>
+        Need an opening parenthesis: (
+      OUT
+    end
+
+    it { should fail_hook }
+  end
+end


### PR DESCRIPTION
`CommitMsg` hook works only on commit messages. Unfortunately
`commitplease` does not allow to pass a message directly on it, it only
works on posted commits. That's why this hooks needs to be moved to
`PostCommit` section - `commitplease` needs to actually see the
commit.