### PR TITLE
Add RakeTarget pre-commit and pre-push hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,7 @@ issue](https://github.com/brigade/overcommit/issues/238) for more details.
 * [Pyflakes](lib/overcommit/hook/pre_commit/pyflakes.rb)
 * [Pylint](lib/overcommit/hook/pre_commit/pylint.rb)
 * [PythonFlake8](lib/overcommit/hook/pre_commit/python_flake8.rb)
+* [RakeTarget](lib/overcommit/hook/pre_commit/rake_target.rb)
 * [RailsBestPractices](lib/overcommit/hook/pre_commit/rails_best_practices.rb)
 * [RailsSchemaUpToDate](lib/overcommit/hook/pre_commit/rails_schema_up_to_date.rb)
 * [Reek](lib/overcommit/hook/pre_commit/reek.rb)
@@ -551,6 +552,7 @@ aborted.
 * [Brakeman](lib/overcommit/hook/pre_push/brakeman.rb)
 * [Minitest](lib/overcommit/hook/pre_push/minitest.rb)
 * [ProtectedBranches](lib/overcommit/hook/pre_push/protected_branches.rb)
+* [RakeTarget](lib/overcommit/hook/pre_push/rake_target.rb)
 * [RSpec](lib/overcommit/hook/pre_push/r_spec.rb)
 * [TestUnit](lib/overcommit/hook/pre_push/test_unit.rb)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -458,6 +458,16 @@ PreCommit:
     install_command: 'pip install flake8'
     include: '**/*.py'
 
+  RakeTarget:
+    enabled: false
+    description: 'Run rake targets'
+    # targets:
+    #  - 'lint'
+    #  - 'validate'
+    #  - '...'
+    required_executable: 'rake'
+    install_command: 'gem install rake'
+
   RailsBestPractices:
     enabled: false
     description: 'Analyze with RailsBestPractices'
@@ -894,6 +904,16 @@ PrePush:
     enabled: false
     description: 'Run RSpec test suite'
     required_executable: 'rspec'
+
+  RakeTarget:
+    enabled: false
+    description: 'Run rake targets'
+    # targets:
+    #  - 'lint'
+    #  - 'validate'
+    #  - '...'
+    required_executable: 'rake'
+    install_command: 'gem install rake'
 
   Minitest:
     enabled: false

--- a/lib/overcommit/hook/pre_commit/rake_target.rb
+++ b/lib/overcommit/hook/pre_commit/rake_target.rb
@@ -1,0 +1,10 @@
+require 'overcommit/hook/shared/rake_target'
+
+module Overcommit::Hook::PreCommit
+  # Runs rake targets
+  #
+  # @see {Overcommit::Hook::Shared::RakeTarget}
+  class RakeTarget < Base
+    include Overcommit::Hook::Shared::RakeTarget
+  end
+end

--- a/lib/overcommit/hook/pre_push/rake_target.rb
+++ b/lib/overcommit/hook/pre_push/rake_target.rb
@@ -1,0 +1,10 @@
+require 'overcommit/hook/shared/rake_target'
+
+module Overcommit::Hook::PrePush
+  # Runs rake targets
+  #
+  # @see {Overcommit::Hook::Shared::RakeTarget}
+  class RakeTarget < Base
+    include Overcommit::Hook::Shared::RakeTarget
+  end
+end

--- a/lib/overcommit/hook/shared/rake_target.rb
+++ b/lib/overcommit/hook/shared/rake_target.rb
@@ -1,0 +1,24 @@
+module Overcommit::Hook::Shared
+  # runs specified rake targets. It fails on the first non-
+  # successfull exit.
+  #
+  module RakeTarget
+    def run
+      targets = config['targets']
+
+      if Array(targets).empty?
+        raise 'RakeTarget: targets parameter is empty. Add at least one task to ' \
+          'the targets parameter. Valid: Array of target names or String of ' \
+          'target names'
+      end
+
+      targets.each do |task|
+        result = execute(command + [task])
+        unless result.success?
+          return :fail, "Rake target #{task}:\n#{result.stdout}"
+        end
+      end
+      :pass
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_commit/rake_target_spec.rb
+++ b/spec/overcommit/hook/pre_commit/rake_target_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::RakeTarget do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  context 'without targets parameters' do
+    let(:result) { double('result') }
+    it 'raises' do
+      expect { subject.run }.to raise_error(
+        RuntimeError, /RakeTarget: targets parameter is empty.*/
+      )
+    end
+  end
+
+  context 'with targets parameter set' do
+    let(:config) do
+      super().merge(Overcommit::Configuration.new(
+        'PreCommit' => {
+          'RakeTarget' => {
+            'targets' => ['test'],
+          }
+        }
+      ))
+    end
+    let(:result) { double('result') }
+
+    context 'when rake exits successfully' do
+      before do
+        result.stub(:success?).and_return(true)
+        subject.stub(:execute).and_return(result)
+        result.stub(:stdout).and_return('ANYTHING')
+      end
+
+      it { should pass }
+    end
+
+    context 'when rake exits unsuccessfully' do
+      before do
+        result.stub(:success?).and_return(false)
+        subject.stub(:execute).and_return(result)
+        result.stub(:stdout).and_return('ANYTHING')
+      end
+
+      it { should fail_hook }
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_push/rake_target_spec.rb
+++ b/spec/overcommit/hook/pre_push/rake_target_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PrePush::RakeTarget do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  context 'without targets parameters' do
+    let(:result) { double('result') }
+    it 'raises' do
+      expect { subject.run }.to raise_error(
+        RuntimeError, /RakeTarget: targets parameter is empty.*/
+      )
+    end
+  end
+
+  context 'with targets parameter set' do
+    let(:config) do
+      super().merge(Overcommit::Configuration.new(
+        'PrePush' => {
+          'RakeTarget' => {
+            'targets' => ['test'],
+          }
+        }
+      ))
+    end
+    let(:result) { double('result') }
+
+    context 'when rake exits successfully' do
+      before do
+        result.stub(:success?).and_return(true)
+        subject.stub(:execute).and_return(result)
+        result.stub(:stdout).and_return('ANYTHING')
+      end
+
+      it { should pass }
+    end
+
+    context 'when rake exits unsuccessfully' do
+      before do
+        result.stub(:success?).and_return(false)
+        subject.stub(:execute).and_return(result)
+        result.stub(:stdout).and_return('ANYTHING')
+      end
+
+      it { should fail_hook }
+    end
+  end
+end


### PR DESCRIPTION
Allow to run rake targets as pre-commit and pre-push hooks.

The first unsuccessfull exit code of a specified rake task
will fail the hook.

Example configuration: 
 
```yaml 
PreCommit: 
  RakeTask: 
    enabled: true 
    targets: 
      - 'validate' 
      - 'lint' 
 
PrePush: 
  RakeTask: 
    enabled: true 
    targets: 
      - 'test' 
```

If considired for merging I would require  a hint howto test for a raised error on missing targets parameter. :-)