### PR TITLE
Add check to make sure ESLint has not failed to run

### DIFF
--- a/lib/overcommit/hook/pre_commit/es_lint.rb
+++ b/lib/overcommit/hook/pre_commit/es_lint.rb
@@ -21,6 +21,8 @@ module Overcommit::Hook::PreCommit
       output = result.stdout.chomp
       return :pass if result.success? && output.empty?
 
+      return [:fail, result.stderr] unless result.stderr.empty?
+
       # example message:
       #   path/to/file.js: line 1, col 0, Error - Error message (ruleName)
       extract_messages(


### PR DESCRIPTION
Previously if the eslint binary fails to run overcommit will simply show all ESLint tests as passing.

This checks to see if eslint has written anything to standard error before simply assuming everything is okay.

Closes #458 