### PR TITLE
Add pre-push hook for pytest

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -900,6 +900,12 @@ PrePush:
     destructive_only: true
     branches: ['master']
 
+  Pytest:
+    enabled: false
+    description: 'Run pytest test suite'
+    required_executable: 'pytest'
+    install_command: 'pip install -U pytest'
+
   RSpec:
     enabled: false
     description: 'Run RSpec test suite'

--- a/lib/overcommit/hook/pre_push/pytest.rb
+++ b/lib/overcommit/hook/pre_push/pytest.rb
@@ -1,0 +1,14 @@
+module Overcommit::Hook::PrePush
+  # Runs `pytest` test suite before push
+  #
+  # @see https://github.com/pytest-dev/pytest
+  class Pytest < Base
+    def run
+      result = execute(command)
+      return :pass if result.success?
+
+      output = result.stdout + result.stderr
+      [:fail, output]
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_push/pytest_spec.rb
+++ b/spec/overcommit/hook/pre_push/pytest_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PrePush::Pytest do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject       { described_class.new(config, context) }
+
+  context 'when pytest exits successfully' do
+    before do
+      result = double('result')
+      result.stub(:success?).and_return(true)
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should pass }
+  end
+
+  context 'when pytest exits unsucessfully' do
+    before do
+      result = double('result')
+      result.stub(:success?).and_return(false)
+      result.stub(:stdout).and_return('Some error message')
+      result.stub(:stderr).and_return('')
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should fail_hook 'Some error message' }
+  end
+end


### PR DESCRIPTION
Add hook for [`pytest`](https://github.com/pytest-dev/pytest), a `python` testing framework.

Closes #462.