### PR TITLE
Make HookContext::PreCommit#initial_commit? public

### DIFF
--- a/lib/overcommit/hook_context/pre_commit.rb
+++ b/lib/overcommit/hook_context/pre_commit.rb
@@ -126,6 +126,12 @@ module Overcommit::HookContext
       @modified_lines[file]
     end
 
+    # Returns whether the current git branch is empty (has no commits).
+    def initial_commit?
+      return @initial_commit unless @initial_commit.nil?
+      @initial_commit = Overcommit::GitRepo.initial_commit?
+    end
+
     private
 
     # Clears the working tree so that the stash can be applied.
@@ -168,12 +174,6 @@ module Overcommit::HookContext
         map { |line| line.gsub(/[^\s]+\s+(.+)/, '\\1') }
 
       modified_files.any?
-    end
-
-    # Returns whether the current git branch is empty (has no commits).
-    def initial_commit?
-      return @initial_commit unless @initial_commit.nil?
-      @initial_commit = Overcommit::GitRepo.initial_commit?
     end
 
     # Stores the modification times for all modified files to make it appear like


### PR DESCRIPTION
Since it's being forwarded to, in Ruby 2.4 it throws a warning.