### PR TITLE
Auto-sign config file when installing hooks the first time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix `forwarding to private method` warning on Ruby 2.4.x
 * Update `childprocess` dependency to 0.6.x series
+* Auto-sign configuration file when installing hooks for the first time
 
 ## 0.38.0
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ mkdir important-project
 cd important-project
 git init
 overcommit --install
-overcommit --sign    # See Security section below for explanation
 ```
 
 See the [Security](#security) section of the documentation to understand why

--- a/lib/overcommit/installer.rb
+++ b/lib/overcommit/installer.rb
@@ -36,6 +36,9 @@ module Overcommit
       install_hook_files
       install_starter_config
 
+      # Auto-sign configuration file on install
+      config(verify: false).update_signature!
+
       log.success "Successfully installed hooks into #{@target}"
     end
 
@@ -179,6 +182,11 @@ module Overcommit
       # Some Ruby implementations (e.g. JRuby) raise an error when the file
       # doesn't exist. Standardize the behavior to return false.
       false
+    end
+
+    # Returns the configuration for this repository.
+    def config(options = {})
+      Overcommit::ConfigurationLoader.new(log, options).load_repo_config
     end
   end
 end

--- a/spec/integration/configuration_signing_spec.rb
+++ b/spec/integration/configuration_signing_spec.rb
@@ -27,8 +27,8 @@ describe 'configuration file signing' do
 
   around do |example|
     repo do
-      echo(config.to_yaml, '.overcommit.yml')
       `overcommit --install > #{File::NULL}`
+      echo(config.to_yaml, '.overcommit.yml')
 
       `overcommit --sign` if configuration_signed
       echo(new_config.to_yaml, '.overcommit.yml')

--- a/spec/integration/installing_overcommit_spec.rb
+++ b/spec/integration/installing_overcommit_spec.rb
@@ -1,6 +1,18 @@
 require 'spec_helper'
 
 describe 'installing Overcommit' do
+  let(:enable_verification) { true }
+
+  it 'signs the configuration file' do
+    repo do
+      `overcommit --install`
+      touch('some-file')
+      `git add some-file`
+      result = shell(%w[git commit --allow-empty -m Test])
+      result.status.should == 0
+    end
+  end
+
   context 'when template directory points to the Overcommit template directory' do
     around do |example|
       repo(template_dir: Overcommit::Installer::TEMPLATE_DIRECTORY) do


### PR DESCRIPTION
Previously, we required users to explicitly run `overcommit --sign` in their repositories after running `overcommit --install`. This was slightly annoying and made for a poor user onboarding experience.

For all practical purposes, the initial bootstrap case seems like one where ease of getting started with the tool trumps the risk of malicious code execution via hooks. It is reasonable to assume that a user who runs `overcommit --install` is accepting responsibility for hook code executed as of that point. It is only on subsequent changes to configuration/hooks that they should be warned to sign the config file/hooks appropriately.