### PR TITLE
ESLint pre-commit hook fails if there are problems

### DIFF
--- a/lib/overcommit/hook/pre_commit/es_lint.rb
+++ b/lib/overcommit/hook/pre_commit/es_lint.rb
@@ -12,9 +12,6 @@ module Overcommit::Hook::PreCommit
   #     enabled: true
   #     command: ['npm', 'run', 'lint', '--', '-f', 'compact']
   #
-  # If ESLint returns some errors, you can bindly pass by
-  # setting `bindly_pass` option to true.
-  #
   # Note: This hook supports only compact format.
   #
   # @see http://eslint.org/
@@ -24,11 +21,7 @@ module Overcommit::Hook::PreCommit
       output = result.stdout.chomp
       messages = output.split("\n").grep(/Warning|Error/)
 
-      # Fail for issues relative to the tool used.
-      if !config['bindly_pass'] && messages.empty? && !result.success?
-        return [:fail, result.stderr]
-      end
-
+      return [:fail, result.stderr] if messages.empty? && !result.success?
       return :pass if result.success? && output.empty?
 
       # example message:

--- a/lib/overcommit/hook/pre_commit/es_lint.rb
+++ b/lib/overcommit/hook/pre_commit/es_lint.rb
@@ -25,7 +25,7 @@ module Overcommit::Hook::PreCommit
       messages = output.split("\n").grep(/Warning|Error/)
 
       # Fail for issues relative to the tool used.
-      if messages.empty? && !result.success?
+      if !config['bindly_pass'] && messages.empty? && !result.success?
         $stderr.puts result.stderrs
         return :fail
       end

--- a/lib/overcommit/hook/pre_commit/es_lint.rb
+++ b/lib/overcommit/hook/pre_commit/es_lint.rb
@@ -26,8 +26,7 @@ module Overcommit::Hook::PreCommit
 
       # Fail for issues relative to the tool used.
       if !config['bindly_pass'] && messages.empty? && !result.success?
-        $stderr.puts result.stderrs
-        return :fail
+        return [:fail, result.stderr]
       end
 
       return :pass if result.success? && output.empty?

--- a/lib/overcommit/hook/pre_commit/es_lint.rb
+++ b/lib/overcommit/hook/pre_commit/es_lint.rb
@@ -39,7 +39,6 @@ module Overcommit::Hook::PreCommit
         /^(?<file>(?:\w:)?[^:]+):[^\d]+(?<line>\d+).*?(?<type>Error|Warning)/,
         lambda { |type| type.downcase.to_sym }
       )
-
     end
   end
 end

--- a/spec/overcommit/hook/pre_commit/es_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/es_lint_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'stringio'
 
 describe Overcommit::Hook::PreCommit::EsLint do
   let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
@@ -7,6 +8,20 @@ describe Overcommit::Hook::PreCommit::EsLint do
 
   before do
     subject.stub(:applicable_files).and_return(%w[file1.js file2.js])
+  end
+
+  context 'when eslint is unable to run' do
+    let(:result) { double('result') }
+
+    before do
+      result.stub(:stderrs).and_return('SyntaxError: Use of const in strict mode.')
+      result.stub(:stdout).and_return('')
+
+      result.stub(:success?).and_return(false)
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should fail_hook }
   end
 
   context 'when eslint exits successfully' do

--- a/spec/overcommit/hook/pre_commit/es_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/es_lint_spec.rb
@@ -13,7 +13,7 @@ describe Overcommit::Hook::PreCommit::EsLint do
     let(:result) { double('result') }
 
     before do
-      result.stub(:stderrs).and_return('SyntaxError: Use of const in strict mode.')
+      result.stub(:stderr).and_return('SyntaxError: Use of const in strict mode.')
       result.stub(:stdout).and_return('')
 
       result.stub(:success?).and_return(false)

--- a/spec/overcommit/hook/pre_commit/es_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/es_lint_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'stringio'
 
 describe Overcommit::Hook::PreCommit::EsLint do
   let(:config)  { Overcommit::ConfigurationLoader.default_configuration }


### PR DESCRIPTION
A user can choose to ignore this behavior by specifying `bindly_pass` option:

```yaml
PreCommit:
  EsLint:
    enabled: true
    on_warn: fail
    bindly_pass: true
```