### PR TITLE
ProtectedBranches should be able to handle pushing tags gracefully

### DIFF
--- a/lib/overcommit/hook/pre_push/protected_branches.rb
+++ b/lib/overcommit/hook/pre_push/protected_branches.rb
@@ -21,6 +21,7 @@ module Overcommit::Hook::PrePush
 
     def protected?(remote_ref)
       ref_name = remote_ref[%r{refs/heads/(.*)}, 1]
+      return false if ref_name.nil?
       protected_branch_patterns.any? do |pattern|
         File.fnmatch(pattern, ref_name)
       end

--- a/spec/overcommit/hook/pre_push/protected_branches_spec.rb
+++ b/spec/overcommit/hook/pre_push/protected_branches_spec.rb
@@ -93,4 +93,14 @@ describe Overcommit::Hook::PrePush::ProtectedBranches do
       include_examples 'protected branch'
     end
   end
+
+  context 'when pushing tags' do
+    let(:pushed_ref_name) { 'redundant' }
+
+    before do
+      pushed_ref.stub(:remote_ref).and_return("refs/tags/#{pushed_ref_name}")
+    end
+
+    it { should pass }
+  end
 end


### PR DESCRIPTION
This is a fix for Issue #480 

When pushing tags, the pushed ref will look something like this:
```
refs/tags/release-0.1 e0250d9551467b32e2292ff163961b3af0f8ac67 refs/tags/release-0.1 0000000000000000000000000000000000000000
```

This does not match the regular expression pattern of `refs/heads`, hence the failure.