### PR TITLE
Add `--no-summary` flag to haml-lint

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -288,6 +288,7 @@ PreCommit:
     description: 'Analyze with haml-lint'
     required_executable: 'haml-lint'
     install_command: 'gem install haml-lint'
+    flags: ['--no-summary']
     include: '**/*.haml'
 
   HardTabs:


### PR DESCRIPTION
Haml-lint now prints a summary at the end of the run. E.g.

  11 files inspected, 1 lint detected

We need to disable that so that overcommit can parse the output
correctly.

Here's some more context: https://github.com/brigade/haml-lint/pull/176

This will help resolve some of the issues seen in #483.