### PR TITLE
Add pre-commit hook for LicenseFinder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add [`Pronto`](https://github.com/mmozuras/pronto) pre-commit hook
 * Add [`hadolint`](https://github.com/lukasmartinelli/hadolint) pre-commit hook
+* Add [`license_finder`](https://github.com/pivotal/LicenseFinder) pre-commit hook
 * Use the `core.hooksPath` Git configuration option when installing hooks
 
 ## 0.39.1

--- a/README.md
+++ b/README.md
@@ -491,6 +491,7 @@ issue](https://github.com/brigade/overcommit/issues/238) for more details.
 * [GoLint](lib/overcommit/hook/pre_commit/go_lint.rb)
 * [GoVet](lib/overcommit/hook/pre_commit/go_vet.rb)
 * [Hadolint](lib/overcommit/hook/pre_commit/hadolint.rb)
+* [LicenseFinder](lib/overcommit/hook/pre_commit/license_finder.rb)
 * [HamlLint](lib/overcommit/hook/pre_commit/haml_lint.rb)
 * [HardTabs](lib/overcommit/hook/pre_commit/hard_tabs.rb)
 * [Hlint](lib/overcommit/hook/pre_commit/hlint.rb)

--- a/config/default.yml
+++ b/config/default.yml
@@ -383,6 +383,21 @@ PreCommit:
     install_command: 'gem install json'
     include: '**/*.json'
 
+  LicenseFinder:
+    enabled: false
+    description: 'Analyze with LicenseFinder'
+    required_executable: 'license_finder'
+    install_command: 'gem install license_finder'
+    include:
+      - 'Gemfile'
+      - 'requirements.txt'
+      - 'package.json'
+      - 'pom.xml'
+      - 'build.gradle'
+      - 'bower.json'
+      - 'Podfile'
+      - 'rebar.config'
+
   LicenseHeader:
     enabled: false
     license_file: 'LICENSE.txt'

--- a/lib/overcommit/hook/pre_commit/license_finder.rb
+++ b/lib/overcommit/hook/pre_commit/license_finder.rb
@@ -1,0 +1,12 @@
+module Overcommit::Hook::PreCommit
+  # Runs LicenseFinder if any of your package manager declaration files have changed
+  # See more about LicenseFinder at https://github.com/pivotal/LicenseFinde
+  class LicenseFinder < Base
+    def run
+      result = execute(command)
+      return :pass if result.success?
+      output = result.stdout + result.stderr
+      [:fail, output]
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_commit/license_finder_spec.rb
+++ b/spec/overcommit/hook/pre_commit/license_finder_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::LicenseFinder do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject       { described_class.new(config, context) }
+
+  context 'when license_finder exits successfully' do
+    before do
+      result = double('result')
+      result.stub(:success?).and_return(true)
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should pass }
+  end
+
+  context 'when license_finder runs unsucessfully' do
+    before do
+      result = double('result')
+      result.stub(:success?).and_return(false)
+      result.stub(:stdout).and_return('Some error message')
+      result.stub(:stderr).and_return('')
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should fail_hook 'Some error message' }
+  end
+end


### PR DESCRIPTION
Closes #482. 

Sorry this took a while to get around to. This adds a pre-commit hook for the [LicenseFinder](https://github.com/pivotal/LicenseFinder) license checker if any package management related files change.