### PR TITLE
Fix support for binary files in LineEndings hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Overcommit Changelog
 
+## master
+
+* Fix binary files detection in `LineEndings` pre-commit hook
+
 ## 0.40.0
 
 * Add [`Pronto`](https://github.com/mmozuras/pronto) pre-commit hook

--- a/lib/overcommit/hook/pre_commit/line_endings.rb
+++ b/lib/overcommit/hook/pre_commit/line_endings.rb
@@ -54,8 +54,8 @@ module Overcommit::Hook::PreCommit
 
       result.stdout.split("\0").map do |file_info|
         i, _w, _attr, path = file_info.split
-        next if i == 'l/-text' # ignore binary files
-        next if i == "l/#{eol}"
+        next if i.match(/\A[li]\/-text\z/) # ignore binary files
+        next if i.match(/\A[li]\/#{eol}\z/)
         path
       end.compact
     end


### PR DESCRIPTION
`LineEndings` hook checks `git ls-files --eol` indexes for `l/-text` for some reason. However, the proper format (at least for git 2.11 and up is `i/-text` (`i` instead of `l`).

This fix corrects that, while keeping backwards compatibility.