### PR TITLE
Re-add hard tab exclusions for makefiles and Go

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -304,6 +304,9 @@ PreCommit:
     quiet: true
     required_executable: 'grep'
     flags: ['-IHn', "\t"]
+    exclude:
+      - '**/Makefile'
+      - '**/*.go'
 
   Hlint:
     enabled: false


### PR DESCRIPTION
This partially reverts 3f7c037b after discussion with @sds.