### PR TITLE
Optionally disable colorized output via env

### DIFF
--- a/lib/overcommit/logger.rb
+++ b/lib/overcommit/logger.rb
@@ -78,7 +78,11 @@ module Overcommit
     # @param partial [true,false] whether to omit a newline
     def color(code, str, partial = false)
       send(partial ? :partial : :log,
-           @out.tty? ? "\033[#{code}m#{str}\033[0m" : str)
+           colorize? ? "\033[#{code}m#{str}\033[0m" : str)
+    end
+
+    def colorize?
+      @out.tty? && ENV.fetch('OVERCOMMIT_COLOR', '1') != '0'
     end
   end
 end

--- a/spec/overcommit/logger_spec.rb
+++ b/spec/overcommit/logger_spec.rb
@@ -80,6 +80,23 @@ describe Overcommit::Logger do
         output.should_not include "\033"
       end
     end
+
+    context 'when colorization is disabled' do
+      before do
+        io.stub(:tty?).and_return(true)
+      end
+
+      around do |example|
+        Overcommit::Utils.with_environment 'OVERCOMMIT_COLOR' => '0' do
+          example.run
+        end
+      end
+
+      it 'omits the color escape sequence' do
+        subject
+        output.should_not include "\033"
+      end
+    end
   end
 
   describe '#debug' do


### PR DESCRIPTION
Colorized output is now disabled if the environment variable `OVERCOMMIT_COLOR` is present with the value `0`.

Fixes #508.