### PR TITLE
Correct LicenseFinder repository link

### DIFF
--- a/lib/overcommit/hook/pre_commit/license_finder.rb
+++ b/lib/overcommit/hook/pre_commit/license_finder.rb
@@ -1,6 +1,6 @@
 module Overcommit::Hook::PreCommit
   # Runs LicenseFinder if any of your package manager declaration files have changed
-  # See more about LicenseFinder at https://github.com/pivotal/LicenseFinde
+  # See more about LicenseFinder at https://github.com/pivotal/LicenseFinder
   class LicenseFinder < Base
     def run
       result = execute(command)


### PR DESCRIPTION
The 'r' at the end of the repository link was missing.