### PR TITLE
Print commit message when commit_msg hooks fail

### DIFF
--- a/lib/overcommit/hook_context/base.rb
+++ b/lib/overcommit/hook_context/base.rb
@@ -102,6 +102,13 @@ module Overcommit::HookContext
       @input_lines ||= input_string.split("\n")
     end
 
+    # Returns a message to display on failure.
+    #
+    # @return [String]
+    def post_fail_message
+      nil
+    end
+
     private
 
     def filter_modified_files(modified_files)

--- a/lib/overcommit/hook_context/commit_msg.rb
+++ b/lib/overcommit/hook_context/commit_msg.rb
@@ -31,6 +31,10 @@ module Overcommit::HookContext
       @args[0]
     end
 
+    def post_fail_message
+      "Failed commit message:\n" + commit_message_lines.join
+    end
+
     private
 
     def raw_commit_message_lines

--- a/lib/overcommit/hook_runner.rb
+++ b/lib/overcommit/hook_runner.rb
@@ -74,7 +74,13 @@ module Overcommit
 
         print_results
 
-        !(@failed || @interrupted)
+        hook_failed = @failed || @interrupted
+
+        if hook_failed && @context.respond_to?(:post_fail_message)
+          puts @context.post_fail_message
+        end
+
+        !hook_failed
       else
         @printer.nothing_to_run
         true # Run was successful

--- a/lib/overcommit/hook_runner.rb
+++ b/lib/overcommit/hook_runner.rb
@@ -76,8 +76,9 @@ module Overcommit
 
         hook_failed = @failed || @interrupted
 
-        if hook_failed && @context.respond_to?(:post_fail_message)
-          puts @context.post_fail_message
+        if hook_failed
+          message = @context.post_fail_message
+          @printer.after(message) unless message.nil?
         end
 
         !hook_failed

--- a/lib/overcommit/printer.rb
+++ b/lib/overcommit/printer.rb
@@ -77,6 +77,12 @@ module Overcommit
       end
     end
 
+    def after(message)
+      log.newline
+      log.log message
+      log.newline
+    end
+
     private
 
     def print_header(hook)

--- a/spec/overcommit/hook_context/base_spec.rb
+++ b/spec/overcommit/hook_context/base_spec.rb
@@ -23,4 +23,10 @@ describe Overcommit::HookContext::Base do
 
     it { should == ['line 1', 'line 2'] }
   end
+
+  describe '#post_fail_message' do
+    subject { context.post_fail_message }
+
+    it { should be_nil }
+  end
 end

--- a/spec/overcommit/hook_context/commit_msg_spec.rb
+++ b/spec/overcommit/hook_context/commit_msg_spec.rb
@@ -85,4 +85,12 @@ describe Overcommit::HookContext::CommitMsg do
       it { should == false }
     end
   end
+
+  describe '#post_fail_message' do
+    subject { context.post_fail_message }
+
+    it 'returns printable log of commit message' do
+      subject.should == "Failed commit message:\nSome commit message\n"
+    end
+  end
 end


### PR DESCRIPTION
>So the user can copy-paste their commit message when trying to commit
again, and not lose it. Removes frustration for users who craft their
commit messages with care.
>
>The user can always get their failed message from `.git/COMMIT_EDITMSG`
(depending on the version of git, I think), but only if they copy before
running `git commit` again, which they may forget to do sometimes.

Fix #494 

I am new to ruby, gems, and this project, so please forgive any "nasties" or other mistakes! I'm happy to change or reimplement this however the maintainers would like =)