### PR TITLE
Fix hook install in submodules

### DIFF
--- a/lib/overcommit/git_config.rb
+++ b/lib/overcommit/git_config.rb
@@ -13,7 +13,7 @@ module Overcommit
 
     def hooks_path
       path = `git config --get core.hooksPath`.chomp
-      return File.join(Overcommit::Utils.repo_root, '.git', 'hooks') if path.empty?
+      return File.join(Overcommit::Utils.git_dir, 'hooks') if path.empty?
       File.absolute_path(path)
     end
   end

--- a/spec/overcommit/installer_spec.rb
+++ b/spec/overcommit/installer_spec.rb
@@ -225,6 +225,27 @@ describe Overcommit::Installer do
           end
         end
       end
+
+      context 'which has an external git dir' do
+        let(:submodule) { File.join(target, 'submodule') }
+        before do
+          system 'git', 'submodule', 'add', target, 'submodule',
+                 chdir: target, out: :close, err: :close
+        end
+        let(:submodule_git_file) { File.join(submodule, '.git') }
+        let(:submodule_git_dir) do
+          File.expand_path(File.read(submodule_git_file)[/gitdir: (.*)/, 1], submodule)
+        end
+        let(:submodule_hooks_dir) { File.join(submodule_git_dir, 'hooks') }
+
+        subject { installer.run(submodule, options) }
+
+        it 'installs hooks into the correct external directory' do
+          expect { subject }.to change {
+            hook_files_installed?(submodule_hooks_dir)
+          }.from(false).to(true)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Joining the repo root doesn't account for `.git` files which have a `gitdir: ...` redirect, but `Overcommit::Utils.git_dir` compensates for that.

### Before

```
my-submodule (master) % overcommit --install
Installing hooks into .../my-repo/vendor/my-submodule
.../lib/ruby/2.4.0/fileutils.rb:230:in `mkdir': File exists @ dir_s_mkdir - .../my-repo/vendor/my-submodule/.git (Errno::EEXIST)
	from .../lib/ruby/2.4.0/fileutils.rb:230:in `fu_mkdir'
	from .../lib/ruby/2.4.0/fileutils.rb:208:in `block (2 levels) in mkdir_p'
	from .../lib/ruby/2.4.0/fileutils.rb:206:in `reverse_each'
	from .../lib/ruby/2.4.0/fileutils.rb:206:in `block in mkdir_p'
	from .../lib/ruby/2.4.0/fileutils.rb:191:in `each'
	from .../lib/ruby/2.4.0/fileutils.rb:191:in `mkdir_p'
	from .../gems/overcommit-0.41.0/lib/overcommit/installer.rb:80:in `ensure_directory'
	from .../gems/overcommit-0.41.0/lib/overcommit/installer.rb:33:in `install'
	from .../gems/overcommit-0.41.0/lib/overcommit/installer.rb:22:in `run'
	from .../gems/overcommit-0.41.0/lib/overcommit/cli.rb:122:in `block in install_or_uninstall'
	from .../gems/overcommit-0.41.0/lib/overcommit/cli.rb:120:in `each'
	from .../gems/overcommit-0.41.0/lib/overcommit/cli.rb:120:in `install_or_uninstall'
	from .../gems/overcommit-0.41.0/lib/overcommit/cli.rb:22:in `run'
	from .../gems/overcommit-0.41.0/bin/overcommit:49:in `<top (required)>'
	from .../bin/overcommit:23:in `load'
	from .../bin/overcommit:23:in `<main>'
```

### After

```
my-submodule (master) % overcommit --install
Installing hooks into .../my-repo/vendor/my-submodule
Successfully installed hooks into .../my-repo/vendor/my-submodule
```

:+1: