### PR TITLE
Fix mdl MESSAGE_REGEX

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -415,7 +415,7 @@ PreCommit:
 
   Mdl:
     enabled: false
-    description: 'Analyze with mdl'
+    description: 'Analyze markdown files with mdl'
     required_executable: 'mdl'
     install_command: 'gem install mdl'
     include: '**/*.md'

--- a/lib/overcommit/hook/pre_commit/mdl.rb
+++ b/lib/overcommit/hook/pre_commit/mdl.rb
@@ -3,7 +3,7 @@ module Overcommit::Hook::PreCommit
   #
   # @see https://github.com/mivok/markdownlint
   class Mdl < Base
-    MESSAGE_REGEX = /^(?<file>(?:\w:)?[^:]+):(?<line>\d+)/
+    MESSAGE_REGEX = /^(?<file>(?:\w:)?[^:]+):(?<line>\d+):\s(?<msg>.+)/
 
     def run
       result = execute(command, args: applicable_files)


### PR DESCRIPTION
While reviewing the `MESSAGE_REGEX` for `mdl`, I noticed that it is incomplete, and is missing the message output of `mdl`. This updates the regular expression to specifically match this output.