### PR TITLE
Run `golint` for each file that has changed

### DIFF
--- a/lib/overcommit/hook/pre_commit/go_lint.rb
+++ b/lib/overcommit/hook/pre_commit/go_lint.rb
@@ -4,8 +4,17 @@ module Overcommit::Hook::PreCommit
   # @see https://github.com/golang/lint
   class GoLint < Base
     def run
-      result = execute(command, args: applicable_files)
-      output = result.stdout + result.stderr
+      output = ''
+      success = true
+
+      # golint doesn't accept multiple file arguments if
+      # they belong to different packages
+      applicable_files.each do |gofile|
+        result = execute(command, args: Array(gofile))
+        output += result.stdout
+        success &&= result.success?
+      end
+      
       # Unfortunately the exit code is always 0
       return :pass if output.empty?
 

--- a/lib/overcommit/hook/pre_commit/go_lint.rb
+++ b/lib/overcommit/hook/pre_commit/go_lint.rb
@@ -5,16 +5,14 @@ module Overcommit::Hook::PreCommit
   class GoLint < Base
     def run
       output = ''
-      success = true
 
       # golint doesn't accept multiple file arguments if
       # they belong to different packages
       applicable_files.each do |gofile|
         result = execute(command, args: Array(gofile))
-        output += result.stdout
-        success &&= result.success?
+        output += result.stdout + result.stderr
       end
-      
+
       # Unfortunately the exit code is always 0
       return :pass if output.empty?
 


### PR DESCRIPTION
Also tracked at #529.

If I change one file `main.go`, then the `GoLint` hook runs `golint main.go` which is desirable and correct.

However, when I change files that belong to multiple packages such as:

1. `main.go`
2. `lib/util.go`

then the `GoLint` hook runs `golint main.go lib/util.go` which will always return the error (regardless of the presence of any lint errors)

> lib/util.go is in package lib, not main

This is because `golint` can only be used in the following way (from `golint --help`:

> Usage of golint:
> 	golint [flags] # runs on package in current directory
> 	golint [flags] [packages]
> 	golint [flags] [directories] # where a '/...' suffix includes all sub-directories
> 	golint [flags] [files] # all must belong to a single package

This means `golint` shouldn't be passed files that belong to different packages. 

This commit fixes this behaviour by running `golint` separately on each file that has changed. And the concatenating all their outputs.