### PR TITLE
Improve performance of Gemfile.lock ignore check for BundleAudit hook

### DIFF
--- a/lib/overcommit/hook/pre_commit/bundle_audit.rb
+++ b/lib/overcommit/hook/pre_commit/bundle_audit.rb
@@ -7,7 +7,8 @@ module Overcommit::Hook::PreCommit
 
     def run
       # Ignore if Gemfile.lock is not tracked by git
-      ignored_files = execute(%W[git ls-files -o -i --exclude-standard -- #{LOCK_FILE}]).stdout.split("\n")
+      ignored_files = execute(%W[git ls-files -o -i --exclude-standard -- #{LOCK_FILE}]).
+                      stdout.split("\n")
       return :pass if ignored_files.include?(LOCK_FILE)
 
       result = execute(command)

--- a/lib/overcommit/hook/pre_commit/bundle_audit.rb
+++ b/lib/overcommit/hook/pre_commit/bundle_audit.rb
@@ -7,7 +7,7 @@ module Overcommit::Hook::PreCommit
 
     def run
       # Ignore if Gemfile.lock is not tracked by git
-      ignored_files = execute(%w[git ls-files -o -i --exclude-standard]).stdout.split("\n")
+      ignored_files = execute(%W[git ls-files -o -i --exclude-standard -- #{LOCK_FILE}]).stdout.split("\n")
       return :pass if ignored_files.include?(LOCK_FILE)
 
       result = execute(command)

--- a/spec/overcommit/hook/pre_commit/bundle_audit_spec.rb
+++ b/spec/overcommit/hook/pre_commit/bundle_audit_spec.rb
@@ -27,7 +27,7 @@ describe Overcommit::Hook::PreCommit::BundleAudit do
     end
 
     before do
-      subject.stub(:execute).with(%w[git ls-files -o -i --exclude-standard]).
+      subject.stub(:execute).with(%w[git ls-files -o -i --exclude-standard -- Gemfile.lock]).
         and_return(double(stdout: ''))
       subject.stub(:execute).with(%w[bundle-audit]).and_return(result)
     end


### PR DESCRIPTION
Listing ignored files in repositories with a lot of ignored files (such as build artifacts) can take a long time.