### PR TITLE
Pass applicable_files argument to RailsBestPractices Hook

### DIFF
--- a/lib/overcommit/hook/pre_commit/rails_best_practices.rb
+++ b/lib/overcommit/hook/pre_commit/rails_best_practices.rb
@@ -8,7 +8,7 @@ module Overcommit
         ERROR_REGEXP = /^(?<file>(?:\w:)?[^:]+):(?<line>\d+)\s-\s(?<type>.+)/
 
         def run
-          result = execute(command)
+          result = execute(command, args: applicable_files)
 
           return :pass if result.success?
           return [:fail, result.stderr] unless result.stderr.empty?

--- a/spec/overcommit/hook/pre_commit/rails_best_practices_spec.rb
+++ b/spec/overcommit/hook/pre_commit/rails_best_practices_spec.rb
@@ -5,6 +5,10 @@ describe Overcommit::Hook::PreCommit::RailsBestPractices do
   let(:context) { double('context') }
   subject { described_class.new(config, context) }
 
+  before do
+    subject.stub(:applicable_files).and_return(%w[file1.rb file2.rb])
+  end
+
   context 'when rails_best_practices exits successfully' do
     before do
       result = double('result')


### PR DESCRIPTION
The `applicable_files` argument wasn't being passed into the `RailsBestPractices` `execute` command during the `run` method. Adding it means that `include`/`exclude` directives in the `.overcommit.yml` function properly.