### PR TITLE
Update Pre-Push Context Modified Files

### DIFF
--- a/lib/overcommit/hook_context/pre_push.rb
+++ b/lib/overcommit/hook_context/pre_push.rb
@@ -17,6 +17,12 @@ module Overcommit::HookContext
       end
     end
 
+    def modified_files
+      @modified_files ||= Overcommit::GitRepo.modified_files(
+        refs: "#{pushed_refs[0].remote_sha1}..#{pushed_refs[0].local_sha1}"
+      )
+    end
+
     PushedRef = Struct.new(:local_ref, :local_sha1, :remote_ref, :remote_sha1) do
       def forced?
         !(created? || deleted? || overwritten_commits.empty?)

--- a/spec/support/git_spec_helpers.rb
+++ b/spec/support/git_spec_helpers.rb
@@ -23,6 +23,14 @@ module GitSpecHelpers
     end
   end
 
+  # Retrieve sha1 based on git ref
+  #
+  # @param ref [String] git ref
+  # @return [String] ref's sha1
+  def get_sha1(ref)
+    `git rev-parse #{ref}`.chomp
+  end
+
   # Creates a directory (with an optional specific name) in a temporary
   # directory which will automatically be destroyed.
   #


### PR DESCRIPTION
Previously, `Overcommit::HookContext::PrePush::modified_files` is set as `[]` which
does not give us any value in `applicable_files` as in `PreCommit` context.

This change updates the method to return list of added and updated files in current branch:

1. compared between current branch and tracking branch if tracking branch is available.

2. compared between current branch with parent branch if tracking branch is not available.

This gives us above values in `applicable_files` in `PrePush` context.

One usage example is we can create a hook to scan prohibited keywords such as `eval`, `console.log`, etc. before pushing to remote. Previously we can only do it in `PreCommit` hook but now we could also do it in `PrePush`.

I think this will also allow us to reuse existing hooks for `PreCommit` in `PrePush` context that relies on `applicable_files` method. 