### PR TITLE
Add more settings files to ChamberSecurity

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -191,8 +191,14 @@ PreCommit:
     flags: ['secure', '--files']
     install_command: 'gem install chamber'
     include:
-      - 'config/settings.yml'
+      - 'config/settings*.yml'
+      - 'config/settings*.yml.erb'
       - 'config/settings/**/*.yml'
+      - 'config/settings/**/*.yml.erb'
+      - 'settings*.yml'
+      - 'settings*.yml.erb'
+      - 'settings/**/*.yml'
+      - 'settings/**/*.yml.erb'
 
   CoffeeLint:
     enabled: false


### PR DESCRIPTION
Previously the files were only looking for where they live when working
in a Rails app.  Now the file set covers more use cases:

* `settings-production.yml` which is a namespaced settings file
* `settings.yml.erb` which is an ERB pre-processed settings file
* Settings which live in projects like Sinatra and a Rubygem