### PR TITLE
Add ChamberCompare hook

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -184,13 +184,18 @@ PreCommit:
     description: 'Check for case-insensitivity conflicts'
     quiet: true
 
-  ChamberSecurity:
+  ChamberCompare:
     enabled: false
-    description: 'Check that settings have been secured with Chamber'
+    description: 'Check that settings are equivalent between namespaces'
     required_executable: 'chamber'
-    flags: ['secure', '--files']
+    flags: ['compare']
     install_command: 'gem install chamber'
-    include:
+    namespaces:
+      - ['development']
+      - ['test']
+      - ['production']
+    exclusions: []
+    include: &chamber_settings_files
       - 'config/settings*.yml'
       - 'config/settings*.yml.erb'
       - 'config/settings/**/*.yml'
@@ -199,6 +204,14 @@ PreCommit:
       - 'settings*.yml.erb'
       - 'settings/**/*.yml'
       - 'settings/**/*.yml.erb'
+
+  ChamberSecurity:
+    enabled: false
+    description: 'Check that settings have been secured with Chamber'
+    required_executable: 'chamber'
+    flags: ['secure', '--files']
+    install_command: 'gem install chamber'
+    include: *chamber_settings_files
 
   CoffeeLint:
     enabled: false

--- a/lib/overcommit/hook/pre_commit/chamber_compare.rb
+++ b/lib/overcommit/hook/pre_commit/chamber_compare.rb
@@ -1,0 +1,41 @@
+module Overcommit::Hook::PreCommit
+  # Runs `chamber compare` against a configurable set of namespaces.
+  #
+  # @see https://github.com/thekompanee/chamber/wiki/Git-Commit-Hooks#chamber-compare-pre-commit-hook
+  # rubocop:disable Metrics/MethodLength
+  class ChamberCompare < Base
+    def run
+      config['namespaces'].each_index do |index|
+        first  = config['namespaces'][index]
+        second = config['namespaces'][index + 1]
+
+        next unless second
+
+        result = execute(
+                   command,
+                   args: [
+                           "--first=#{first.join(' ')}",
+                           "--second=#{second.join(' ')}",
+                         ],
+                 )
+
+        unless result.stdout.empty?
+          trimmed_result = result.stdout.split("\n")
+          5.times { trimmed_result.shift }
+          trimmed_result = trimmed_result.join("\n")
+
+          return [
+                   :warn,
+                   "It appears your namespace settings between #{first} and " \
+                   "#{second} are not in sync:\n\n#{trimmed_result}\n\n" \
+                   "Run: chamber compare --first=#{first.join(' ')} " \
+                   "--second=#{second.join(' ')}",
+                 ]
+        end
+      end
+
+      :pass
+    end
+  end
+  # rubocop:enable Metrics/MethodLength
+end

--- a/spec/overcommit/hook/pre_commit/chamber_compare_spec.rb
+++ b/spec/overcommit/hook/pre_commit/chamber_compare_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::ChamberCompare do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject       { described_class.new(config, context) }
+
+  before do
+    subject.stub(:applicable_files).and_return(['my_settings.yml'])
+  end
+
+  context 'when chamber exits successfully' do
+    before do
+      result = double('result')
+      result.stub(:stdout).and_return('')
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should pass }
+  end
+
+  context 'when chamber exits unsucessfully' do
+    before do
+      result = double('result')
+      result.stub(:stdout).and_return('Some error message')
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should warn }
+  end
+end


### PR DESCRIPTION
One of the pain points that can arise from adding settings to your
application is if you've set a new (required) item in `development` and
`test`, so it works locally and the tests pass, but you've forgotten to
set it in `production`.

Then, you deploy your app only to have it blow up, which sets your
customers out with pitchforks for your head.

Fortunately Chamber provides an easy solution.  Whenever you commit
settings files, Chamber can automatically verify the settings of
multiple different namespace sets to ensure that they're all consistent.

For example, it can take `development`, `test` and `production` and
verify that all the keys that exist in one, exist in the other two.  If
that isn't the case, the hook will fail and the commit will abort.

You can enable it by creating an `.overcommit.yml` file and adding:

```yaml
ChamberCompare:
  enabled: true
```

This hook has an additional option:

| Name         | Description                                                                                                                                                                                             | Example                                       |
| ---          | ---                                                                                                                                                                                                     | ---                                           |
| `namespaces` | This is an array of arrays of namespaces to compare to each other. Typically each inner array will only have one item (the environment) but if you wanted to do a more intensive comparison, you could. | `[['development'], ['test'], ['production']]` |