### PR TITLE
Prohibited Keyword under PreCommit Hook

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -477,13 +477,6 @@ PreCommit:
     flags: ['--standard=PSR2', '--report=csv']
     include: '**/*.php'
 
-  Pronto:
-    enabled: false
-    description: 'Analyzing with pronto'
-    required_executable: 'pronto'
-    install_command: 'gem install pronto'
-    flags: ['run', '--staged', '--exit-code']
-
   ProhibitedKeyword:
     enabled: false
     description: 'Check for prohibited keywords'
@@ -491,6 +484,13 @@ PreCommit:
       - console.log(
       - binding.pry
       - eval(
+
+  Pronto:
+    enabled: false
+    description: 'Analyzing with pronto'
+    required_executable: 'pronto'
+    install_command: 'gem install pronto'
+    flags: ['run', '--staged', '--exit-code']
 
   PuppetLint:
     enabled: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -484,6 +484,14 @@ PreCommit:
     install_command: 'gem install pronto'
     flags: ['run', '--staged', '--exit-code']
 
+  ProhibitedKeyword:
+    enabled: false
+    description: 'Check for prohibited keywords'
+    keywords:
+      - console.log(
+      - binding.pry
+      - eval(
+
   PuppetLint:
     enabled: false
     description: 'Analyze with puppet-lint'
@@ -1016,14 +1024,6 @@ PrePush:
     requires_files: false
     required: false
     quiet: false
-
-  ProhibitedKeyword:
-    enabled: false
-    description: 'Check for prohibited keywords'
-    keywords:
-      - console.log(
-      - binding.pry
-      - eval(
 
   ProtectedBranches:
     enabled: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -1017,6 +1017,14 @@ PrePush:
     required: false
     quiet: false
 
+  ProhibitedKeyword:
+    enabled: false
+    description: 'Check for prohibited keywords'
+    keywords:
+      - console.log(
+      - binding.pry
+      - eval(
+
   ProtectedBranches:
     enabled: false
     description: 'Check for illegal pushes to protected branches'

--- a/lib/overcommit/hook/pre_commit/prohibited_keyword.rb
+++ b/lib/overcommit/hook/pre_commit/prohibited_keyword.rb
@@ -21,7 +21,7 @@ module Overcommit::Hook::PreCommit
     end
 
     def prohibited_keywords
-      @prohibited_keywords ||= Array(config[:keywords])
+      @prohibited_keywords ||= Array(config['keywords'])
     end
   end
 end

--- a/lib/overcommit/hook/pre_commit/prohibited_keyword.rb
+++ b/lib/overcommit/hook/pre_commit/prohibited_keyword.rb
@@ -1,0 +1,27 @@
+module Overcommit::Hook::PreCommit
+  class ProhibitedKeyword < Base
+    def run
+      errors = []
+
+      applicable_files.each do |file|
+        if File.read(file) =~ /(#{formatted_keywords})/
+          errors << "#{file}: contains prohibited keyword.`"
+        end
+      end
+
+      return :fail, errors.join("\n") if errors.any?
+
+      :pass
+    end
+
+    private
+
+    def formatted_keywords
+      prohibited_keywords.map { |keyword| Regexp.quote(keyword) }.join('|')
+    end
+
+    def prohibited_keywords
+      @prohibited_keywords ||= Array(config[:keywords])
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_commit/prohibited_keyword_spec.rb
+++ b/spec/overcommit/hook/pre_commit/prohibited_keyword_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+require 'overcommit/hook_context/pre_push'
+
+describe Overcommit::Hook::PreCommit::ProhibitedKeyword do
+  let(:hook_config) { { keywords: ['console.log(', 'eval('] } }
+  let(:config) do
+    Overcommit::ConfigurationLoader.default_configuration.merge(
+      Overcommit::Configuration.new(
+        'PreCommit' => { 'ProhibitedKeyword' => hook_config }
+      )
+    )
+  end
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  context 'with blacklisted keyword' do
+    let(:file) { create_file('console.log("hello")') }
+
+    context 'with matching file' do
+      before do
+        subject.stub(:applicable_files).and_return([file.path])
+      end
+
+      it { should fail_hook /contains prohibited keyword./ }
+    end
+
+    context 'without matching file' do
+      before do
+        subject.stub(:applicable_files).and_return([])
+      end
+
+      it { should pass }
+    end
+  end
+
+  context 'without blacklisted keyword' do
+    let(:file) { create_file('alert("hello")') }
+    before do
+      subject.stub(:applicable_files).and_return([file.path])
+    end
+
+    context 'with matching file' do
+      before do
+        subject.stub(:applicable_files).and_return([file.path])
+      end
+
+      it { should pass }
+    end
+
+    context 'without matching file' do
+      before do
+        subject.stub(:applicable_files).and_return([])
+      end
+
+      it { should pass }
+    end
+  end
+
+  private
+
+  def create_file(content)
+    Tempfile.new('index.html').tap do |file|
+      file.write(content)
+      file.close
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_commit/prohibited_keyword_spec.rb
+++ b/spec/overcommit/hook/pre_commit/prohibited_keyword_spec.rb
@@ -3,13 +3,7 @@ require 'overcommit/hook_context/pre_push'
 
 describe Overcommit::Hook::PreCommit::ProhibitedKeyword do
   let(:hook_config) { { keywords: ['console.log(', 'eval('] } }
-  let(:config) do
-    Overcommit::ConfigurationLoader.default_configuration.merge(
-      Overcommit::Configuration.new(
-        'PreCommit' => { 'ProhibitedKeyword' => hook_config }
-      )
-    )
-  end
+  let(:config) { Overcommit::ConfigurationLoader.default_configuration }
   subject { described_class.new(config, context) }
 
   context 'with blacklisted keyword' do

--- a/spec/overcommit/hook/pre_commit/prohibited_keyword_spec.rb
+++ b/spec/overcommit/hook/pre_commit/prohibited_keyword_spec.rb
@@ -10,24 +10,19 @@ describe Overcommit::Hook::PreCommit::ProhibitedKeyword do
       )
     )
   end
-  let(:context) { double('context') }
   subject { described_class.new(config, context) }
 
   context 'with blacklisted keyword' do
     let(:file) { create_file('console.log("hello")') }
 
     context 'with matching file' do
-      before do
-        subject.stub(:applicable_files).and_return([file.path])
-      end
+      let(:context) { double('context', modified_files: [file.path]) }
 
       it { should fail_hook /contains prohibited keyword./ }
     end
 
     context 'without matching file' do
-      before do
-        subject.stub(:applicable_files).and_return([])
-      end
+      let(:context) { double('context', modified_files: []) }
 
       it { should pass }
     end
@@ -35,22 +30,15 @@ describe Overcommit::Hook::PreCommit::ProhibitedKeyword do
 
   context 'without blacklisted keyword' do
     let(:file) { create_file('alert("hello")') }
-    before do
-      subject.stub(:applicable_files).and_return([file.path])
-    end
 
     context 'with matching file' do
-      before do
-        subject.stub(:applicable_files).and_return([file.path])
-      end
+      let(:context) { double('context', modified_files: [file.path]) }
 
       it { should pass }
     end
 
     context 'without matching file' do
-      before do
-        subject.stub(:applicable_files).and_return([])
-      end
+      let(:context) { double('context', modified_files: []) }
 
       it { should pass }
     end


### PR DESCRIPTION
Created this out of my own frustration because there was too many times I've committed things
such as `console.log` or `binding.pry` to my Pull Requests.

This is a simple check on prohibited keywords based on the list of keywords that we set in config yml.

This is useful for projects that need to blacklist few keywords/functions from being committed.