### PR TITLE
Extract Install Hooks Common Code

### DIFF
--- a/lib/overcommit/hook/shared/bower_install.rb
+++ b/lib/overcommit/hook/shared/bower_install.rb
@@ -1,13 +1,15 @@
+require 'overcommit/hook/shared/simple_install'
+
 module Overcommit::Hook::Shared
   # Shared code used by all BowerInstall hooks. Runs `bower install` when a
   # change is detected in the repository's dependencies.
   #
   # @see http://bower.io/
   module BowerInstall
-    def run
-      result = execute(command)
-      return :fail, result.stderr unless result.success?
-      :pass
+    include SimpleInstall
+
+    def fail_output
+      @result.stderr
     end
   end
 end

--- a/lib/overcommit/hook/shared/bundle_install.rb
+++ b/lib/overcommit/hook/shared/bundle_install.rb
@@ -1,13 +1,15 @@
+require 'overcommit/hook/shared/simple_install'
+
 module Overcommit::Hook::Shared
   # Shared code used by all BundleInstall hooks. Runs `bundle install` when a
   # change is detected in the repository's dependencies.
   #
   # @see http://bundler.io/
   module BundleInstall
-    def run
-      result = execute(command)
-      return :fail, result.stdout unless result.success?
-      :pass
+    include SimpleInstall
+
+    def fail_output
+      @result.stdout
     end
   end
 end

--- a/lib/overcommit/hook/shared/composer_install.rb
+++ b/lib/overcommit/hook/shared/composer_install.rb
@@ -1,13 +1,15 @@
+require 'overcommit/hook/shared/simple_install'
+
 module Overcommit::Hook::Shared
   # Shared code used by all ComposerInstall hooks. Runs `composer install` when
   # a change is detected in the repository's dependencies.
   #
   # @see https://getcomposer.org/
   module ComposerInstall
-    def run
-      result = execute(command)
-      return :fail, result.stdout unless result.success?
-      :pass
+    include SimpleInstall
+
+    def fail_output
+      @result.stdout
     end
   end
 end

--- a/lib/overcommit/hook/shared/npm_install.rb
+++ b/lib/overcommit/hook/shared/npm_install.rb
@@ -1,13 +1,15 @@
+require 'overcommit/hook/shared/simple_install'
+
 module Overcommit::Hook::Shared
   # Shared code used by all NpmInstall hooks. Runs `npm install` when a change
   # is detected in the repository's dependencies.
   #
   # @see https://www.npmjs.com/
   module NpmInstall
-    def run
-      result = execute(command)
-      return :fail, result.stderr unless result.success?
-      :pass
+    include SimpleInstall
+
+    def fail_output
+      @result.stderr
     end
   end
 end

--- a/lib/overcommit/hook/shared/simple_install.rb
+++ b/lib/overcommit/hook/shared/simple_install.rb
@@ -1,0 +1,14 @@
+module Overcommit::Hook::Shared
+  # Simple template for X-Install hooks.
+  module SimpleInstall
+    def run
+      @result = execute(command)
+      return :fail, fail_output unless @result.success?
+      :pass
+    end
+
+    def fail_output
+      raise NotImplementedError
+    end
+  end
+end

--- a/lib/overcommit/hook/shared/yarn_install.rb
+++ b/lib/overcommit/hook/shared/yarn_install.rb
@@ -1,13 +1,15 @@
+require 'overcommit/hook/shared/simple_install'
+
 module Overcommit::Hook::Shared
   # Shared code used by all YarnInstall hooks. Runs `yarn install` when a change
   # is detected in the repository's dependencies.
   #
   # @see https://yarnpkg.com/
   module YarnInstall
-    def run
-      result = execute(command)
-      return :fail, result.stderr unless result.success?
-      :pass
+    include SimpleInstall
+
+    def fail_output
+      @result.stderr
     end
   end
 end


### PR DESCRIPTION
While working on adding `ComposerInstall` hook in d9ac62e7ba9d0b8aa5c66c8998894e8e90f7d87f,
I noticed all the Install hooks mostly look the same with minor difference.

Extracted the common code to `SimpleInstall` module making things DRYer.