### PR TITLE
Add support for git-worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,6 @@ This project aims to support the following Ruby runtimes on both \*nix and Windo
 
 * MRI 2.x
 
-## Limitations
-
-Overcommit does not currently support
-[`git-worktree`](https://git-scm.com/docs/git-worktree) (introduced in Git 2.5),
-but there is an [open issue](https://github.com/brigade/overcommit/issues/336)
-tracking progress on adding support.
-
 ### Dependencies
 
 Some of the hooks have third-party dependencies. For example, to lint your

--- a/lib/overcommit/git_config.rb
+++ b/lib/overcommit/git_config.rb
@@ -14,7 +14,7 @@ module Overcommit
     def hooks_path
       path = `git config --get core.hooksPath`.chomp
       return File.join(Overcommit::Utils.git_dir, 'hooks') if path.empty?
-      File.absolute_path(path)
+      File.absolute_path(path, Dir.pwd)
     end
   end
 end

--- a/spec/overcommit/utils_spec.rb
+++ b/spec/overcommit/utils_spec.rb
@@ -52,27 +52,13 @@ describe Overcommit::Utils do
       end
     end
 
-    context 'when .git is a file' do
-      before do
-        FileUtils.rm_rf('.git', secure: true)
-        echo("gitdir: #{git_dir_path}", '.git')
-      end
+    context 'when .git directory is not located in the repository' do
+      let(:git_dir) { Dir.mktmpdir }
+      let(:repo_dir) { repo(git_dir: git_dir) }
 
-      context 'and is a relative path' do
-        let(:git_dir_path) { '../.git' }
-
-        it 'returns the path contained in the file' do
-          # realpath is so spec passes on Mac OS X
-          subject.should == File.join(File.realpath(File.dirname(repo_dir)), '.git')
-        end
-      end
-
-      context 'and is an absolute path' do
-        let(:git_dir_path) { '/some/arbitrary/path/.git' }
-
-        it 'returns the path contained in the file' do
-          subject.should == git_dir_path
-        end
+      it 'returns the path of the external Git directory' do
+        # realpath is so spec passes on Mac OS X
+        subject.should == File.realpath(git_dir)
       end
     end
   end

--- a/spec/support/git_spec_helpers.rb
+++ b/spec/support/git_spec_helpers.rb
@@ -11,7 +11,12 @@ module GitSpecHelpers
   # @return [String] path of the repository
   def repo(options = {})
     directory('some-repo') do
-      `git init --template="#{options[:template_dir]}"`
+      create_cmd = %w[git init]
+      create_cmd += ['--template', options[:template_dir]] if options[:template_dir]
+      create_cmd += ['--separate-git-dir', options[:git_dir]] if options[:git_dir]
+
+      result = Overcommit::Utils.execute(create_cmd)
+      raise "Unable to create repo: #{result.stderr}" unless result.success?
 
       # Need to define user info since some CI contexts don't have defaults set
       `git config --local user.name "Overcommit Tester"`


### PR DESCRIPTION
Main reason we didn't previously support work trees was because we had assumed that the `.git` directory was always located in the repository root. With separate work trees, this is not necessarily the case.

Add support by using Git commands to fetch the location of the `GIT_DIR` instead of trying to determine it ourself.
