### PR TITLE
Add support for cargo test

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1117,6 +1117,13 @@ PrePush:
     flags: ['--exit-on-warn', '--quiet', '--summary']
     install_command: 'gem install brakeman'
 
+  CargoTest:
+    enabled: false
+    description: 'Run tests with cargo'
+    required_executable: 'cargo'
+    flags: ['test']
+    include: 'src/**/*.rs'
+
   GitLfs:
     enabled: false
     description: 'Upload files tracked by Git LFS'

--- a/lib/overcommit/hook/pre_push/cargo_test.rb
+++ b/lib/overcommit/hook/pre_push/cargo_test.rb
@@ -1,0 +1,10 @@
+module Overcommit::Hook::PrePush
+  # Runs `cargo test` before push if Rust files changed
+  class CargoTest < Base
+    def run
+      result = execute(command)
+      return :pass if result.success?
+      [:fail, result.stdout]
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_push/cargo_test_spec.rb
+++ b/spec/overcommit/hook/pre_push/cargo_test_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PrePush::CargoTest do
+  let(:config) { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  context 'when all tests succeed' do
+    before do
+      result = double('result')
+      result.stub(:success?).and_return(true)
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should pass }
+  end
+
+  context 'when one test fails' do
+    before do
+      result = double('result')
+      result.stub(:success?).and_return(false)
+      result.stub(stdout: <<-ERRORMSG)
+        running 2 tests
+        test tests::foo ... ok
+        test tests::bar ... FAILED
+
+        failures:
+
+        ---- tests::bar stdout ----
+                thread 'tests::bar' panicked at 'assertion failed: `(left == right)`
+          left: `None`,
+         right: `Some(Bar)`', src/foobar.rs:88:9
+        note: Run with `RUST_BACKTRACE=1` for a backtrace.
+
+
+        failures:
+          tests::bar
+
+        test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
+      ERRORMSG
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should fail_hook }
+  end
+end


### PR DESCRIPTION
Adds support for running tests with Rust's [Cargo](https://github.com/rust-lang/cargo).