### PR TITLE
git rev-parse gives wrong result in git 1.17.10

### DIFF
--- a/lib/overcommit/utils.rb
+++ b/lib/overcommit/utils.rb
@@ -59,7 +59,9 @@ module Overcommit
       def git_dir
         @git_dir ||=
           begin
-            result = execute(%w[git rev-parse --git-dir])
+            cmd = %w[git rev-parse]
+            cmd << GIT_VERSION < '2.5' ? '--git-dir' : '--git-common-dir'
+            result = execute(cmd)
             unless result.success?
               raise Overcommit::Exceptions::InvalidGitRepo,
                     'Unable to determine location of GIT_DIR. ' \

--- a/lib/overcommit/utils.rb
+++ b/lib/overcommit/utils.rb
@@ -59,7 +59,7 @@ module Overcommit
       def git_dir
         @git_dir ||=
           begin
-            result = execute(%w[git rev-parse --git-common-dir])
+            result = execute(%w[git rev-parse --git-dir])
             unless result.success?
               raise Overcommit::Exceptions::InvalidGitRepo,
                     'Unable to determine location of GIT_DIR. ' \


### PR DESCRIPTION
Strangly enough the --common-git-dir option just returns "--git-common-dir" with git version 1.17.10 if no $GIT_COMMON_DIR defined. The only way I can get correct answer is to stick to --git-dir.