### PR TITLE
Added min_subject_width to TextWidth

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -108,6 +108,7 @@ CommitMsg:
     enabled: true
     description: 'Check text width'
     max_subject_width: 60
+    min_subject_width: 0
     max_body_width: 72
 
   TrailingPeriod:

--- a/lib/overcommit/hook/commit_msg/text_width.rb
+++ b/lib/overcommit/hook/commit_msg/text_width.rb
@@ -24,7 +24,8 @@ module Overcommit::Hook::CommitMsg
       min_subject_width = config['min_subject_width']
       return unless subject.length > max_subject_width || subject.length < min_subject_width
 
-      @errors << "Please keep the subject <= #{max_subject_width} characters and >= #{min_subject_width}"
+      @errors << "Please keep the subject <= #{max_subject_width} and >= " \
+                 "#{min_subject_width} characters"
     end
 
     def find_errors_in_body(lines)

--- a/lib/overcommit/hook/commit_msg/text_width.rb
+++ b/lib/overcommit/hook/commit_msg/text_width.rb
@@ -21,9 +21,10 @@ module Overcommit::Hook::CommitMsg
       max_subject_width =
         config['max_subject_width'] +
         special_prefix_length(subject)
-      return unless subject.length > max_subject_width
+      min_subject_width = config['min_subject_width']
+      return unless subject.length > max_subject_width || subject.length < min_subject_width
 
-      @errors << "Please keep the subject <= #{max_subject_width} characters"
+      @errors << "Please keep the subject <= #{max_subject_width} characters and >= #{min_subject_width}"
     end
 
     def find_errors_in_body(lines)

--- a/spec/overcommit/hook/commit_msg/text_width_spec.rb
+++ b/spec/overcommit/hook/commit_msg/text_width_spec.rb
@@ -99,6 +99,7 @@ describe Overcommit::Hook::CommitMsg::TextWidth do
         'CommitMsg' => {
           'TextWidth' => {
             'max_subject_width' => 70,
+            'min_subject_width' => 4,
             'max_body_width' => 80
           }
         }
@@ -107,6 +108,12 @@ describe Overcommit::Hook::CommitMsg::TextWidth do
 
     context 'when subject is longer than 70 characters' do
       let(:commit_msg) { 'A' * 71 }
+
+      it { should warn /subject/ }
+    end
+
+    context 'when subject is less than 4 characters' do
+      let(:commit_msg) { 'A' * 3 }
 
       it { should warn /subject/ }
     end


### PR DESCRIPTION
I added the support of `min_subject_width` in `TextWidth` with default value as `0` to obtain a behavior like the actual one.

```yaml
  TextWidth:
    min_subject_width: 0
```

A developer can set the `min_subject_width` to improve the commit messages in the team, for example a co-worker can avoid the `EmptyMessage` check putting as subject a single char.