### PR TITLE
[FEATURE] Pre-commit hook: check your yard documentation coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ issue](https://github.com/brigade/overcommit/issues/238) for more details.
 * [BundleOutdated](lib/overcommit/hook/pre_commit/bundle_outdated.rb)
 * [`*`CaseConflicts](lib/overcommit/hook/pre_commit/case_conflicts.rb)
 * [ChamberSecurity](lib/overcommit/hook/pre_commit/chamber_security.rb)
+* [CheckYardCoverage](lib/overcommit/hook/pre_commit/check_yard_coverage.rb)
 * [CoffeeLint](lib/overcommit/hook/pre_commit/coffee_lint.rb)
 * [Credo](lib/overcommit/hook/pre_commit/credo.rb)
 * [CssLint](lib/overcommit/hook/pre_commit/css_lint.rb)

--- a/config/default.yml
+++ b/config/default.yml
@@ -222,6 +222,17 @@ PreCommit:
     install_command: 'gem install chamber'
     include: *chamber_settings_files
 
+  CheckYardCoverage:
+    enabled: false
+    description: 'Checking for yard coverage'
+    command: 'yard'
+    flags: ['--private', 'protected']
+    required_executable: 'yard'
+    install_command: 'gem install yard'
+    min_coverage_percentage: 100
+    include:
+      - '/**/*.rb'
+
   CoffeeLint:
     enabled: false
     description: 'Analyze with coffeelint'

--- a/lib/overcommit/hook/pre_commit/check_yard_coverage.rb
+++ b/lib/overcommit/hook/pre_commit/check_yard_coverage.rb
@@ -1,0 +1,59 @@
+
+module Overcommit::Hook::PreCommit
+  # Class to check yard documentation coverage.
+  #
+  # Use option "min_coverage_percentage" in your CheckYardCoverage configuration
+  # to set your desired documentation coverage percentage.
+  #
+  class CheckYardCoverage < Base
+    def run
+      # Run a no-stats yard command to get the coverage
+      args = %w[-n --no-save --list-undoc --compact] + flags + applicable_files
+      result = execute(command, args: args)
+
+      warnings_and_stats_text, undocumented_objects_text = result.stdout.split('Undocumented Objects:')
+
+      warnings_and_stats = warnings_and_stats_text.strip.split("\n")
+
+      # Stats are the last 7 lines before the undocumented objects
+      stats = warnings_and_stats[-7..100]
+
+      # If no stats present (shouldn't happen), warn the user and end
+      unless stats
+        return [:warn, 'Impossible to read the yard stats. Please, check your yard installation.']
+      end
+
+      # Check the yard doc coverage percentage
+      yard_coverage = nil
+      if config['min_coverage_percentage']
+        match = stats.last.match(/^\s*([\d.]+)%\s+documented\s*$/)
+        if match
+          yard_coverage = match.captures[0].to_f
+          if yard_coverage >= config['min_coverage_percentage'].to_f
+            return :pass
+          end
+        else
+          return [:warn, 'Impossible to read the yard documentation coverage. Please, check your yard installation.']
+        end
+      end
+
+      first_message = "You have a #{yard_coverage}% yard documentation coverage. "\
+                      "#{config['min_coverage_percentage']}% is the minimum required."
+
+      # Add the undocumented objects text as error messages
+      messages = [Overcommit::Hook::Message.new(:error, nil, nil, first_message)]
+      undocumented_objects = undocumented_objects_text.strip.split("\n")
+      undocumented_objects.each do |undocumented_object|
+        undocumented_object_message, file_info = undocumented_object.split(/:?\s+/)
+        file_info_match = file_info.match(/^\(([^:]+):(\d+)\)/)
+        # In case any compacted error does not follow the format, ignore it
+        if file_info_match
+          file = file_info_match.captures[0]
+          line = file_info_match.captures[1]
+          messages << Overcommit::Hook::Message.new(:error, file, line, "#{file}:#{line}: #{undocumented_object_message}")
+        end
+      end
+      messages
+    end
+  end
+end

--- a/spec/overcommit/hook/pre_commit/check_yard_coverage_spec.rb
+++ b/spec/overcommit/hook/pre_commit/check_yard_coverage_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::CheckYardCoverage do
+  let(:config)  { Overcommit::ConfigurationLoader.default_configuration }
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+
+  before do
+    subject.stub(:applicable_files).and_return(%w[file1.rb file2.rb])
+  end
+
+  context 'when yard exits successfully' do
+    before do
+      result = double('result')
+      result.stub(:stdout).and_return(
+        <<-HEREDOC
+      Files:          72
+      Modules:        12 (    0 undocumented)
+      Classes:        63 (    0 undocumented)
+      Constants:      91 (    0 undocumented)
+      Attributes:     11 (    0 undocumented)
+      Methods:       264 (    0 undocumented)
+      100.0% documented
+      HEREDOC
+      )
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should pass }
+  end
+
+  context 'when somehow yard exits a non-stats output' do
+    before do
+      result = double('result')
+      result.stub(:stdout).and_return(
+        <<-HEREDOC
+        WHATEVER OUTPUT THAT IS NOT YARD STATS ONE
+      HEREDOC
+      )
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should warn }
+  end
+
+  context 'when somehow yard coverage is not a valid value' do
+    before do
+      result = double('result')
+      result.stub(:stdout).and_return(
+        <<-HEREDOC
+      Files:          72
+      Modules:        12 (    0 undocumented)
+      Classes:        63 (    0 undocumented)
+      Constants:      91 (    0 undocumented)
+      Attributes:     11 (    0 undocumented)
+      Methods:       264 (    0 undocumented)
+      AAAAAA documented
+      HEREDOC
+      )
+      subject.stub(:execute).and_return(result)
+    end
+
+    it { should warn }
+  end
+
+  context 'when yard exits unsucessfully' do
+    let(:result) { double('result') }
+
+    before do
+      result.stub(:success?).and_return(false)
+      subject.stub(:execute).and_return(result)
+    end
+
+    context 'and it reports an error' do
+      before do
+        result.stub(:stdout).and_return(
+        <<-HEREDOC
+        Files:          72
+        Modules:        12 (    3 undocumented)
+        Classes:        63 (   15 undocumented)
+        Constants:      91 (   79 undocumented)
+        Attributes:     11 (    0 undocumented)
+        Methods:       264 (   55 undocumented)
+        65.53% documented
+
+        Undocumented Objects:
+        ApplicationCable                                                  (app/channels/application_cable/channel.rb:1)
+        ApplicationCable::Channel                                         (app/channels/application_cable/channel.rb:2)
+        ApplicationCable::Connection                                      (app/channels/application_cable/connection.rb:2)
+        HEREDOC
+        )
+      end
+
+      it { should fail_hook }
+    end
+  end
+end


### PR DESCRIPTION
# New Feature: Pre-commit hook to check your yard documentation coverage:

## Introduction

This **pre-commit hook** forces the developers to write yard docs in our code before commiting their changes. This is a good way to review the changes before commiting them. Thus, it make sure the code has some minimal quality.

## Requirements
[yard](https://github.com/lsegal/yard)

## Configuration

### Default configuration for this hook
Note the 100% minimum documentation coverage required. Setting a 100% of documentation coverage is like the Boy Scouts rule: _Leave your code better than you found it_.

```yml
  CheckYardCoverage:
    enabled: false
    description: 'Checking for yard coverage'
    command: 'yard'
    flags: ['--private', 'protected']
     required_executable: 'yard'
    install_command: 'gem install yard'
    min_coverage_percentage: 100
    include:
      - '/**/*.rb'
```
### Example configuration for this hook
```yml
    CheckYardCoverage:
      enabled: true
      flags: ['--private', 'protected']
      min_coverage_percentage: 75
      include:
        - '/app/controllers/*.rb'
        - '/app/facades/*.rb'
        - '/app/libs/*.rb'
        - '/app/models/**.rb'
        - '/app/presenters/*.rb'
```

## Tests

RSpec tests that check the following conditions:
- No undocumented code.
- Couldn't get the yard stats (only possible if yard stats changes its output format).
- Couldn't get the yard stats (only possible if yard stats changes its output format).
- Actual coverage value is less than required one, report an error.
