### PR TITLE
Fix TsLint defaults

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -727,7 +727,6 @@ PreCommit:
       description: 'Analyze with TSLint'
       required_executable: 'tslint'
       install_command: 'npm install -g tslint typescript'
-      flags: ['--t=prose']
       include: '**/*.ts'
 
   TrailingWhitespace:


### PR DESCRIPTION
Removes flags from TsLint default config, which appeared to break linting. 
The "prose" option for `-t` is also default, so shouldn't be necessary to specify as a flag?

I'm running with `tslint` 5.11.0.

Without the default flags:
```
Running pre-commit hooks
Check for trailing whitespace....................[TrailingWhitespace] OK
Check for local paths in Gemfile................[LocalPathsInGemfile] OK
Check for "token" strings.....................................[FixMe] OK
Check if database schema is up to date..........[RailsSchemaUpToDate] OK
Check YAML syntax........................................[YamlSyntax] OK
Analyze with TSLint..........................................[TsLint] OK
Check Gemfile dependencies..............................[BundleCheck] OK
Analyze with RuboCop........................................[RuboCop] OK

✓ All pre-commit hooks passed
```

When overriding flags to `[]`:
```
Running pre-commit hooks
Check if database schema is up to date..........[RailsSchemaUpToDate] OK
Check for local paths in Gemfile................[LocalPathsInGemfile] OK
Check for "token" strings.....................................[FixMe] OK
Check for trailing whitespace....................[TrailingWhitespace] OK
Check YAML syntax........................................[YamlSyntax] OK
Check Gemfile dependencies..............................[BundleCheck] OK
Analyze with TSLint..........................................[TsLint] FAILED
Unexpected output: unable to determine line number or type of error/warning for output:

ERROR: app/javascript/model/EtsState.ts[1, 10]: Named imports must be alphabetized.
ERROR: app/javascript/model/EtsState.ts[3, 18]: An interface declaring no members is equivalent to its supertype.
ERROR: app/javascript/model/EtsState.ts[3, 49]: Unnecessary semicolon
ERROR: app/javascript/model/EtsState.ts[7, 2]: Missing semicolon
ERROR: app/javascript/model/EtsState.ts[11, 2]: file should end with a newline
ERROR: app/javascript/model/index.ts[1, 28]: file should end with a newline
ERROR: app/javascript/reducers/etsReducer.ts[2, 10]: Named imports must be alphabetized.
ERROR: app/javascript/reducers/etsReducer.ts[8, 4]: file should end with a newline
ERROR: app/javascript/reducers/index.ts[1, 30]: file should end with a newline
ERROR: app/javascript/store.ts[1, 38]: Module 'history' is not listed as dependency in package.json
ERROR: app/javascript/store.ts[3, 10]: Named imports must be alphabetized.
ERROR: app/javascript/store.ts[7, 10]: Named imports must be alphabetized.
ERROR: app/javascript/store.ts[15, 2]: Missing semicolon
ERROR: app/javascript/store.ts[26, 3]: file should end with a newline
Analyze with RuboCop........................................[RuboCop] OK

✗ One or more pre-commit hooks failed
```

As is, there are _definitely_ lint errors in the working files.