### PR TITLE
Fix TsLint error message extractor

### DIFF
--- a/lib/overcommit/hook/pre_commit/ts_lint.rb
+++ b/lib/overcommit/hook/pre_commit/ts_lint.rb
@@ -11,7 +11,7 @@ module Overcommit::Hook::PreCommit
       # src/file/anotherfile.ts[298, 1]: exceeds maximum line length of 140
       extract_messages(
           output.split("\n"),
-          /^(?<file>.+?(?=\[))[^\d]+(?<line>\d+).*?/
+          /^ERROR: (?<file>.+?(?=\[))[^\d]+(?<line>\d+).*?/
       )
     end
   end


### PR DESCRIPTION
Fix format of TsLint error message extractor.

I'm running with `tslint` 5.11.0 with default settings for output and my output looks like this:
```
ERROR: /Users/dchiu/Developer/ets/app/javascript/model/EtsState.ts[1, 10]: Named imports must be alphabetized.
ERROR: /Users/dchiu/Developer/ets/app/javascript/model/EtsState.ts[3, 18]: An interface declaring no members is equivalent to its supertype.
ERROR: /Users/dchiu/Developer/ets/app/javascript/model/EtsState.ts[3, 49]: Unnecessary semicolon
ERROR: /Users/dchiu/Developer/ets/app/javascript/model/EtsState.ts[7, 2]: Missing semicolon
ERROR: /Users/dchiu/Developer/ets/app/javascript/model/EtsState.ts[11, 2]: file should end with a newline
ERROR: /Users/dchiu/Developer/ets/app/javascript/model/index.ts[1, 28]: file should end with a newline
ERROR: /Users/dchiu/Developer/ets/app/javascript/packs/application.tsx[8, 1]: Import sources within a group must be alphabetized.
ERROR: /Users/dchiu/Developer/ets/app/javascript/packs/application.tsx[8, 38]: 'withRouter' is declared but its value is never read.
ERROR: /Users/dchiu/Developer/ets/app/javascript/packs/application.tsx[19, 35]: Missing trailing comma
ERROR: /Users/dchiu/Developer/ets/app/javascript/packs/application.tsx[43, 2]: file should end with a newline
ERROR: /Users/dchiu/Developer/ets/app/javascript/pages/Inbox.tsx[11, 2]: file should end with a newline
ERROR: /Users/dchiu/Developer/ets/app/javascript/reducers/etsReducer.ts[2, 10]: Named imports must be alphabetized.
ERROR: /Users/dchiu/Developer/ets/app/javascript/reducers/etsReducer.ts[8, 4]: file should end with a newline
ERROR: /Users/dchiu/Developer/ets/app/javascript/reducers/index.ts[1, 30]: file should end with a newline
ERROR: /Users/dchiu/Developer/ets/app/javascript/store.ts[1, 38]: Module 'history' is not listed as dependency in package.json
ERROR: /Users/dchiu/Developer/ets/app/javascript/store.ts[3, 10]: Named imports must be alphabetized.
ERROR: /Users/dchiu/Developer/ets/app/javascript/store.ts[7, 10]: Named imports must be alphabetized.
ERROR: /Users/dchiu/Developer/ets/app/javascript/store.ts[7, 10]: 'IEtsState' is declared but its value is never read.
ERROR: /Users/dchiu/Developer/ets/app/javascript/store.ts[15, 2]: Missing semicolon
ERROR: /Users/dchiu/Developer/ets/app/javascript/store.ts[26, 3]: file should end with a newline
```

The regex for the message extractor looks like it may be missing the "ERROR: "? As is I get this output when running `overcommit -r`:

```
Unexpected output: unable to determine line number or type of error/warning for output:

ERROR: app/javascript/model/EtsState.ts[1, 10]: Named imports must be alphabetized.
ERROR: app/javascript/model/EtsState.ts[3, 18]: An interface declaring no members is equivalent to its supertype.
ERROR: app/javascript/model/EtsState.ts[3, 49]: Unnecessary semicolon
ERROR: app/javascript/model/EtsState.ts[7, 2]: Missing semicolon
ERROR: app/javascript/model/EtsState.ts[11, 2]: file should end with a newline
ERROR: app/javascript/model/index.ts[1, 28]: file should end with a newline
ERROR: app/javascript/reducers/etsReducer.ts[2, 10]: Named imports must be alphabetized.
ERROR: app/javascript/reducers/etsReducer.ts[8, 4]: file should end with a newline
ERROR: app/javascript/reducers/index.ts[1, 30]: file should end with a newline
ERROR: app/javascript/store.ts[1, 38]: Module 'history' is not listed as dependency in package.json
ERROR: app/javascript/store.ts[3, 10]: Named imports must be alphabetized.
ERROR: app/javascript/store.ts[7, 10]: Named imports must be alphabetized.
ERROR: app/javascript/store.ts[15, 2]: Missing semicolon
ERROR: app/javascript/store.ts[26, 3]: file should end with a newline

✗ One or more pre-commit hooks failed
```

Which is still useful, but seems like overcommit is complaining that it's confused about the message format.