### PR TITLE
Ruumba PreCommit hook (based on RuboCop)

### DIFF
--- a/lib/overcommit/hook/pre_commit/ruumba.rb
+++ b/lib/overcommit/hook/pre_commit/ruumba.rb
@@ -1,0 +1,7 @@
+module Overcommit::Hook::PreCommit
+  # Runs `ruumba` (`rubocop`) against any modified ERB files.
+  #
+  # @see https://github.com/ericqweinstein/ruumba
+  class Ruumba < RuboCop
+  end
+end


### PR DESCRIPTION
This adds proper support for [Ruumba](https://github.com/ericqweinstein/ruumba), a RuboCop-based analyzer for `.erb` (view) files.

Although based on RuboCop, that tool alone just checks `.rb` files.

I'm opening this early to collect any feedback.

TODO list:
- [ ] Check this is actually worthwhile (and a completed PR would be accepted)!
- [X] Implement new PreCommit hook.
- [ ] Define Ruumba default config.
- [ ] Documentation to describe / link to the cop code.
- [ ] Implement tests (based entirely on RuboCop tests?).
- [ ] Rebase / squash and write detailed commit message.

Dependencies:
- [ ] Resolve path-display problem with RuboCop's `emacs` formatter - see [ruumba issue](https://github.com/ericqweinstein/ruumba/issues/19).

I believe there's no new logic actually required for passing the params, nor parsing the output (as that comes directly from RuboCop), hence I've simply inherited everything from the existing `Overcommit::Hook::PreCommit::RuboCop` class.

Note: without this PR, Ruumba can already be used by adding the config below to your `.ruumba.yml`, but every pre-commit execution will run ruumba against every file (not just changed files) so it is prohibitively slow, and the errors are (naturally) not parsed neatly.

```yaml
PreCommit:
  Ruumba:
    enabled: true
    description: 'Analyze view files with Ruumba (RuboCop)'
    command: ['bundle', 'exec', 'ruumba']
    required_executable: 'ruumba'
    flags: ['--display-cop-names', '--format=simple', '--disable-ruby-ext', '--config', '.ruumba.yml']
    install_command: 'gem install ruumba'
    include:
      - '**/*.erb'
```
