### PR TITLE
Add support for new TsLint output format

### DIFF
--- a/lib/overcommit/hook/pre_commit/ts_lint.rb
+++ b/lib/overcommit/hook/pre_commit/ts_lint.rb
@@ -2,16 +2,24 @@ module Overcommit::Hook::PreCommit
   # Runs `tslint` against modified TypeScript files.
   # @see http://palantir.github.io/tslint/
   class TsLint < Base
+    # example message:
+    # "src/file/anotherfile.ts[298, 1]: exceeds maximum line length of 140"
+    # or
+    # "ERROR: src/AccountController.ts[4, 28]: expected call-signature to have a typedef"
+    MESSAGE_REGEX = /^(?<type>.+: )?(?<file>.+?(?=\[))[^\d]+(?<line>\d+).*?/
+
     def run
       result = execute(command, args: applicable_files)
       output = result.stdout.chomp
       return :pass if result.success? && output.empty?
 
-      # example message:
-      # src/file/anotherfile.ts[298, 1]: exceeds maximum line length of 140
+      output_lines = output.split("\n").map(&:strip).reject(&:empty?)
+      type_categorizer = ->(type) { type.nil? || type.include?('ERROR') ? :error : :warning }
+
       extract_messages(
-          output.split("\n"),
-          /^(?<file>.+?(?=\[))[^\d]+(?<line>\d+).*?/
+          output_lines,
+          MESSAGE_REGEX,
+          type_categorizer
       )
     end
   end

--- a/spec/overcommit/hook/pre_commit/ts_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/ts_lint_spec.rb
@@ -36,12 +36,32 @@ describe Overcommit::Hook::PreCommit::TsLint do
 
     context 'and it reports an error' do
       before do
-        result.stub(:stdout).and_return([
+        result.stub(:stdout).and_return(
           'src/file/anotherfile.ts[298, 1]: exceeds maximum line length of 140'
-        ].join("\n"))
+        )
       end
 
       it { should fail_hook }
+    end
+
+    context 'and it reports an error with an "ERROR" severity' do
+      before do
+        result.stub(:stdout).and_return(
+          'ERROR: src/AccountController.ts[4, 28]: expected call-signature to have a typedef'
+        )
+      end
+
+      it { should fail_hook }
+    end
+
+    context 'and it reports an warning' do
+      before do
+        result.stub(:stdout).and_return(
+          'WARNING: src/AccountController.ts[4, 28]: expected call-signature to have a typedef'
+        )
+      end
+
+      it { should warn }
     end
   end
 end


### PR DESCRIPTION
Fixes a bug with the newer TsLint version (eg. 5.10.0) where a severity is added to the output:
> src/file/anotherfile.ts[298, 1]: exceeds maximum line length of 140

becomes 

> ERROR: src/file/anotherfile.ts[298, 1]: exceeds maximum line length of 140

Adapted the regexp to be able to extract from both versions. Also extracts the severity of the TsLint output, eg. `:warning` or `:error`.

Related to: https://github.com/brigade/overcommit/pull/595