### PR TITLE
Add more information to the BundleCheck error msg

### DIFF
--- a/lib/overcommit/hook/pre_commit/bundle_check.rb
+++ b/lib/overcommit/hook/pre_commit/bundle_check.rb
@@ -22,7 +22,8 @@ module Overcommit::Hook::PreCommit
 
       new_lockfile = File.read(LOCK_FILE) if File.exist?(LOCK_FILE)
       if previous_lockfile != new_lockfile
-        return :fail, "#{LOCK_FILE} is not up-to-date -- run `#{command.join(' ')}`"
+        return :fail, "#{LOCK_FILE} is not up-to-date -- run \
+        `#{command.join(' ')}` or add the Gemfile and/or Gemfile.lock".squeeze
       end
 
       :pass


### PR DESCRIPTION
TL;DR Add more information on BundleCheck hook error => (...)`or add the Gemfile and/or Gemfile.lock`

Hey guys, 

I was going to add this hook for my work team and I found there I can improve the message of error.
`Run 'bundle check'` it's good, BUT, I already have the problem of a team member that forgot to include the `Gemfile.lock` (What makes the `bundle check` return a happy ok message).

So, I added this piece of information to remember people to commit both Gemfile files :) 