### PR TITLE
Use Hash#fetch with block

### DIFF
--- a/lib/overcommit/configuration.rb
+++ b/lib/overcommit/configuration.rb
@@ -41,7 +41,7 @@ module Overcommit
       @concurrency ||=
         begin
           cores = Overcommit::Utils.processor_count
-          content = @hash.fetch('concurrency', '%<processors>d')
+          content = @hash.fetch('concurrency') { '%<processors>d' }
           if content.is_a?(String)
             concurrency_expr = content % { processors: cores }
 
@@ -154,7 +154,7 @@ module Overcommit
     # environment variables.
     def apply_environment!(hook_context, env)
       skipped_hooks = "#{env['SKIP']} #{env['SKIP_CHECKS']} #{env['SKIP_HOOKS']}".split(/[:, ]/)
-      only_hooks = env.fetch('ONLY', '').split(/[:, ]/)
+      only_hooks = env.fetch('ONLY') { '' }.split(/[:, ]/)
       hook_type = hook_context.hook_class_name
 
       if only_hooks.any? || skipped_hooks.include?('all') || skipped_hooks.include?('ALL')
@@ -252,7 +252,7 @@ module Overcommit
     private
 
     def ad_hoc_hook?(hook_context, hook_name)
-      ad_hoc_conf = @hash.fetch(hook_context.hook_class_name, {}).fetch(hook_name, {})
+      ad_hoc_conf = @hash.fetch(hook_context.hook_class_name) { {} }.fetch(hook_name) { {} }
 
       # Ad hoc hooks are neither built-in nor have a plugin file written but
       # still have a `command` specified to be run
@@ -282,7 +282,7 @@ module Overcommit
           hook_context_or_type.hook_class_name
         end
 
-      individual_enabled = @hash[hook_type].fetch(hook_name, {})['enabled']
+      individual_enabled = @hash[hook_type].fetch(hook_name) { {} }['enabled']
       return individual_enabled unless individual_enabled.nil?
 
       all_enabled = @hash[hook_type]['ALL']['enabled']

--- a/lib/overcommit/configuration_loader.rb
+++ b/lib/overcommit/configuration_loader.rb
@@ -65,7 +65,7 @@ module Overcommit
       config = self.class.load_from_file(file, default: false, logger: @log)
       config = self.class.default_configuration.merge(config)
 
-      if @options.fetch(:verify, config.verify_signatures?)
+      if @options.fetch(:verify) { config.verify_signatures? }
         verify_signatures(config)
       end
 

--- a/lib/overcommit/configuration_validator.rb
+++ b/lib/overcommit/configuration_validator.rb
@@ -57,8 +57,8 @@ module Overcommit
       errors = []
 
       Overcommit::Utils.supported_hook_type_classes.each do |hook_type|
-        hash.fetch(hook_type, {}).each do |hook_name, hook_config|
-          hook_env = hook_config.fetch('env', {})
+        hash.fetch(hook_type) { {} }.each do |hook_name, hook_config|
+          hook_env = hook_config.fetch('env') { {} }
 
           unless hook_env.is_a?(Hash)
             errors << "#{hook_type}::#{hook_name} has an invalid `env` specified: " \
@@ -95,7 +95,7 @@ module Overcommit
       errors = []
 
       Overcommit::Utils.supported_hook_type_classes.each do |hook_type|
-        hash.fetch(hook_type, {}).each_key do |hook_name|
+        hash.fetch(hook_type) { {} }.each_key do |hook_name|
           next if hook_name == 'ALL'
 
           unless hook_name =~ /\A[A-Za-z0-9]+\z/
@@ -122,7 +122,7 @@ module Overcommit
       any_warnings = false
 
       Overcommit::Utils.supported_hook_type_classes.each do |hook_type|
-        hash.fetch(hook_type, {}).each do |hook_name, hook_config|
+        hash.fetch(hook_type) { {} }.each do |hook_name, hook_config|
           next if hook_name == 'ALL'
 
           if hook_config['enabled'].nil?
@@ -143,8 +143,8 @@ module Overcommit
 
       errors = []
       Overcommit::Utils.supported_hook_type_classes.each do |hook_type|
-        hash.fetch(hook_type, {}).each do |hook_name, hook_config|
-          processors = hook_config.fetch('processors', 1)
+        hash.fetch(hook_type) { {} }.each do |hook_name, hook_config|
+          processors = hook_config.fetch('processors') { 1 }
           if processors > concurrency
             errors << "#{hook_type}::#{hook_name} `processors` value " \
                       "(#{processors}) is larger than the global `concurrency` " \

--- a/lib/overcommit/hook/base.rb
+++ b/lib/overcommit/hook/base.rb
@@ -42,7 +42,7 @@ module Overcommit::Hook
       if output = check_for_requirements
         status = :fail
       else
-        result = Overcommit::Utils.with_environment(@config.fetch('env', {})) { run }
+        result = Overcommit::Utils.with_environment(@config.fetch('env') { {} }) { run }
         status, output = process_hook_return_value(result)
       end
 
@@ -66,7 +66,7 @@ module Overcommit::Hook
     end
 
     def processors
-      @config.fetch('processors', 1)
+      @config.fetch('processors') { 1 }
     end
 
     def quiet?
@@ -270,9 +270,9 @@ module Overcommit::Hook
     def transform_status(status)
       case status
       when :fail
-        @config.fetch('on_fail', :fail).to_sym
+        @config.fetch('on_fail') { :fail }.to_sym
       when :warn
-        @config.fetch('on_warn', :warn).to_sym
+        @config.fetch('on_warn') { :warn }.to_sym
       else
         status
       end

--- a/lib/overcommit/hook/pre_commit/chamber_verification.rb
+++ b/lib/overcommit/hook/pre_commit/chamber_verification.rb
@@ -5,7 +5,7 @@ module Overcommit::Hook::PreCommit
   # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   class ChamberVerification < Base
     def run
-      approver_name  = config.fetch('approver_name', 'your approver')
+      approver_name  = config.fetch('approver_name') { 'your approver' }
       approver_email = config['approver_email'] ? " (#{config['approver_email']})" : nil
 
       result = execute(command)

--- a/lib/overcommit/logger.rb
+++ b/lib/overcommit/logger.rb
@@ -38,7 +38,7 @@ module Overcommit
 
     # Write a line of output if debug mode is enabled.
     def debug(*args)
-      color('35', *args) unless ENV.fetch('OVERCOMMIT_DEBUG', '').empty?
+      color('35', *args) unless ENV.fetch('OVERCOMMIT_DEBUG') { '' }.empty?
     end
 
     # Write a line of output that is intended to be emphasized.

--- a/lib/overcommit/utils.rb
+++ b/lib/overcommit/utils.rb
@@ -172,7 +172,7 @@ module Overcommit
         end
 
         result =
-          if (splittable_args = options.fetch(:args, [])).any?
+          if (splittable_args = options.fetch(:args) { [] }).any?
             debug(initial_args.join(' ') + " ... (#{splittable_args.length} splittable args)")
             Overcommit::CommandSplitter.execute(initial_args, options)
           else

--- a/spec/support/shell_helpers.rb
+++ b/spec/support/shell_helpers.rb
@@ -21,10 +21,10 @@ module ShellHelpers
   # @param options [Hash]
   # @raise [Timeout::TimeoutError] timeout has elapsed before condition holds
   def wait_until(options = {})
-    Timeout.timeout(options.fetch(:timeout, 1)) do
+    Timeout.timeout(options.fetch(:timeout) { 1 }) do
       loop do
         return if yield
-        sleep options.fetch(:check_interval, 0.1)
+        sleep options.fetch(:check_interval) { 0.1 }
       end
     end
   end


### PR DESCRIPTION
According to `fasterer`, "Hash#fetch with second argument is slower than Hash#fetch with block"

This provides a very small improvement but since this gem is used with various workflows I feel that any speed improvement is a win.

Before

```
Finished in 1 minute 12.6 seconds (files took 0.49573 seconds to load)
1343 examples, 0 failures
```

After

```
Finished in 1 minute 12.47 seconds (files took 0.48929 seconds to load)
1343 examples, 0 failures
```