### PR TITLE
Prepare for frozen string literals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 Layout/ClosingParenthesisIndentation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.2
 
 Layout/ClosingParenthesisIndentation:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/bin/overcommit
+++ b/bin/overcommit
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Check if Overcommit should invoke a Bundler context for loading gems
 require 'yaml'

--- a/lib/overcommit.rb
+++ b/lib/overcommit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/os'
 require 'overcommit/constants'
 require 'overcommit/exceptions'

--- a/lib/overcommit/command_splitter.rb
+++ b/lib/overcommit/command_splitter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit
   # Distributes a list of arguments over multiple invocations of a command.
   #

--- a/lib/overcommit/configuration.rb
+++ b/lib/overcommit/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'digest'
 require 'json'
 

--- a/lib/overcommit/configuration_validator.rb
+++ b/lib/overcommit/configuration_validator.rb
@@ -1,4 +1,6 @@
-# rubocop:disable Metrics/ClassLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength, Metrics/LineLength
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/ClassLength, Metrics/MethodLength, Metrics/LineLength
 module Overcommit
   # Validates and normalizes a configuration.
   class ConfigurationValidator
@@ -82,8 +84,8 @@ module Overcommit
       end
 
       if errors.any?
-        @log.error errors.join("\n") if @log
-        @log.newline if @log
+        @log&.error errors.join("\n")
+        @log&.newline
         raise Overcommit::Exceptions::ConfigurationError,
               'One or more hooks had an invalid `env` configuration option'
       end
@@ -107,8 +109,8 @@ module Overcommit
       end
 
       if errors.any?
-        @log.error errors.join("\n") if @log
-        @log.newline if @log
+        @log&.error errors.join("\n")
+        @log&.newline
         raise Overcommit::Exceptions::ConfigurationError,
               'One or more hooks had invalid names'
       end
@@ -154,8 +156,8 @@ module Overcommit
       end
 
       if errors.any?
-        @log.error errors.join("\n") if @log
-        @log.newline if @log
+        @log&.error errors.join("\n")
+        @log&.newline
         raise Overcommit::Exceptions::ConfigurationError,
               'One or more hooks had invalid `processor` value configured'
       end

--- a/lib/overcommit/configuration_validator.rb
+++ b/lib/overcommit/configuration_validator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength, Metrics/MethodLength, Metrics/LineLength
+# rubocop:disable Metrics/ClassLength, Metrics/CyclomaticComplexity, Metrics/MethodLength
 module Overcommit
   # Validates and normalizes a configuration.
   class ConfigurationValidator
@@ -183,4 +183,4 @@ module Overcommit
     end
   end
 end
-# rubocop:enable Metrics/ClassLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength, Metrics/LineLength
+# rubocop:enable Metrics/ClassLength, Metrics/CyclomaticComplexity, Metrics/MethodLength

--- a/lib/overcommit/configuration_validator.rb
+++ b/lib/overcommit/configuration_validator.rb
@@ -84,8 +84,10 @@ module Overcommit
       end
 
       if errors.any?
-        @log&.error errors.join("\n")
-        @log&.newline
+        if @log
+          @log.error errors.join("\n")
+          @log.newline
+        end
         raise Overcommit::Exceptions::ConfigurationError,
               'One or more hooks had an invalid `env` configuration option'
       end
@@ -109,8 +111,10 @@ module Overcommit
       end
 
       if errors.any?
-        @log&.error errors.join("\n")
-        @log&.newline
+        if @log
+          @log.error errors.join("\n")
+          @log.newline
+        end
         raise Overcommit::Exceptions::ConfigurationError,
               'One or more hooks had invalid names'
       end
@@ -156,8 +160,10 @@ module Overcommit
       end
 
       if errors.any?
-        @log&.error errors.join("\n")
-        @log&.newline
+        if @log
+          @log.error errors.join("\n")
+          @log.newline
+        end
         raise Overcommit::Exceptions::ConfigurationError,
               'One or more hooks had invalid `processor` value configured'
       end

--- a/lib/overcommit/constants.rb
+++ b/lib/overcommit/constants.rb
@@ -3,10 +3,10 @@
 # Global application constants.
 module Overcommit
   HOME = File.expand_path(File.join(File.dirname(__FILE__), '..', '..')).freeze
-  CONFIG_FILE_NAME = '.overcommit.yml'.freeze
+  CONFIG_FILE_NAME = '.overcommit.yml'
 
   HOOK_DIRECTORY = File.join(HOME, 'lib', 'overcommit', 'hook').freeze
 
-  REPO_URL = 'https://github.com/brigade/overcommit'.freeze
-  BUG_REPORT_URL = "#{REPO_URL}/issues".freeze
+  REPO_URL = 'https://github.com/brigade/overcommit'
+  BUG_REPORT_URL = "#{REPO_URL}/issues"
 end

--- a/lib/overcommit/constants.rb
+++ b/lib/overcommit/constants.rb
@@ -3,10 +3,10 @@
 # Global application constants.
 module Overcommit
   HOME = File.expand_path(File.join(File.dirname(__FILE__), '..', '..')).freeze
-  CONFIG_FILE_NAME = '.overcommit.yml'
+  CONFIG_FILE_NAME = '.overcommit.yml'.freeze
 
   HOOK_DIRECTORY = File.join(HOME, 'lib', 'overcommit', 'hook').freeze
 
-  REPO_URL = 'https://github.com/brigade/overcommit'
-  BUG_REPORT_URL = "#{REPO_URL}/issues"
+  REPO_URL = 'https://github.com/brigade/overcommit'.freeze
+  BUG_REPORT_URL = "#{REPO_URL}/issues".freeze
 end

--- a/lib/overcommit/exceptions.rb
+++ b/lib/overcommit/exceptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Exceptions
   # Raised when a {Configuration} could not be loaded from a file.
   class ConfigurationError < StandardError; end

--- a/lib/overcommit/git_config.rb
+++ b/lib/overcommit/git_config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/utils'
 
 module Overcommit

--- a/lib/overcommit/git_repo.rb
+++ b/lib/overcommit/git_repo.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'iniparse'
 
 module Overcommit

--- a/lib/overcommit/git_version.rb
+++ b/lib/overcommit/git_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Returns the version of the available git binary.
 #
 # This is intended to be used to conveniently execute code based on a specific

--- a/lib/overcommit/hook/base.rb
+++ b/lib/overcommit/hook/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 require 'overcommit/message_processor'
 

--- a/lib/overcommit/hook/commit_msg/base.rb
+++ b/lib/overcommit/hook/commit_msg/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 
 module Overcommit::Hook::CommitMsg

--- a/lib/overcommit/hook/commit_msg/capitalized_subject.rb
+++ b/lib/overcommit/hook/commit_msg/capitalized_subject.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::CommitMsg
   # Ensures commit message subject lines start with a capital letter.
   class CapitalizedSubject < Base

--- a/lib/overcommit/hook/commit_msg/empty_message.rb
+++ b/lib/overcommit/hook/commit_msg/empty_message.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::CommitMsg
   # Checks that the commit message is not empty
   class EmptyMessage < Base

--- a/lib/overcommit/hook/commit_msg/gerrit_change_id.rb
+++ b/lib/overcommit/hook/commit_msg/gerrit_change_id.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::CommitMsg
   # Ensures a Gerrit Change-Id line is included in the commit message.
   #

--- a/lib/overcommit/hook/commit_msg/hard_tabs.rb
+++ b/lib/overcommit/hook/commit_msg/hard_tabs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::CommitMsg
   # Checks for hard tabs in commit messages.
   class HardTabs < Base

--- a/lib/overcommit/hook/commit_msg/message_format.rb
+++ b/lib/overcommit/hook/commit_msg/message_format.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::CommitMsg
   # Ensures the commit message follows a specific format.
   class MessageFormat < Base

--- a/lib/overcommit/hook/commit_msg/russian_novel.rb
+++ b/lib/overcommit/hook/commit_msg/russian_novel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::CommitMsg
   # Checks for long commit messages (not good or bad--just fun to point out)
   class RussianNovel < Base

--- a/lib/overcommit/hook/commit_msg/single_line_subject.rb
+++ b/lib/overcommit/hook/commit_msg/single_line_subject.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::CommitMsg
   # Ensures commit message subject lines are followed by a blank line.
   class SingleLineSubject < Base

--- a/lib/overcommit/hook/commit_msg/spell_check.rb
+++ b/lib/overcommit/hook/commit_msg/spell_check.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tempfile'
 
 module Overcommit::Hook::CommitMsg

--- a/lib/overcommit/hook/commit_msg/text_width.rb
+++ b/lib/overcommit/hook/commit_msg/text_width.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::CommitMsg
   # Ensures the number of columns the subject and commit message lines occupy is
   # under the preferred limits.

--- a/lib/overcommit/hook/commit_msg/trailing_period.rb
+++ b/lib/overcommit/hook/commit_msg/trailing_period.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::CommitMsg
   # Ensures commit message subject lines do not have a trailing period
   class TrailingPeriod < Base

--- a/lib/overcommit/hook/post_checkout/base.rb
+++ b/lib/overcommit/hook/post_checkout/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 
 module Overcommit::Hook::PostCheckout

--- a/lib/overcommit/hook/post_checkout/bower_install.rb
+++ b/lib/overcommit/hook/post_checkout/bower_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/bower_install'
 
 module Overcommit::Hook::PostCheckout

--- a/lib/overcommit/hook/post_checkout/bundle_install.rb
+++ b/lib/overcommit/hook/post_checkout/bundle_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/bundle_install'
 
 module Overcommit::Hook::PostCheckout

--- a/lib/overcommit/hook/post_checkout/composer_install.rb
+++ b/lib/overcommit/hook/post_checkout/composer_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/composer_install'
 
 module Overcommit::Hook::PostCheckout

--- a/lib/overcommit/hook/post_checkout/index_tags.rb
+++ b/lib/overcommit/hook/post_checkout/index_tags.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/index_tags'
 
 module Overcommit::Hook::PostCheckout

--- a/lib/overcommit/hook/post_checkout/npm_install.rb
+++ b/lib/overcommit/hook/post_checkout/npm_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/npm_install'
 
 module Overcommit::Hook::PostCheckout

--- a/lib/overcommit/hook/post_checkout/submodule_status.rb
+++ b/lib/overcommit/hook/post_checkout/submodule_status.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/submodule_status'
 
 module Overcommit::Hook::PostCheckout

--- a/lib/overcommit/hook/post_checkout/yarn_install.rb
+++ b/lib/overcommit/hook/post_checkout/yarn_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/yarn_install'
 
 module Overcommit::Hook::PostCheckout

--- a/lib/overcommit/hook/post_commit/base.rb
+++ b/lib/overcommit/hook/post_commit/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 
 module Overcommit::Hook::PostCommit

--- a/lib/overcommit/hook/post_commit/bower_install.rb
+++ b/lib/overcommit/hook/post_commit/bower_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/bower_install'
 
 module Overcommit::Hook::PostCommit

--- a/lib/overcommit/hook/post_commit/bundle_install.rb
+++ b/lib/overcommit/hook/post_commit/bundle_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/bundle_install'
 
 module Overcommit::Hook::PostCommit

--- a/lib/overcommit/hook/post_commit/commitplease.rb
+++ b/lib/overcommit/hook/post_commit/commitplease.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PostCommit
   # Check that a commit message conforms to a certain style
   #

--- a/lib/overcommit/hook/post_commit/composer_install.rb
+++ b/lib/overcommit/hook/post_commit/composer_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/composer_install'
 
 module Overcommit::Hook::PostCommit

--- a/lib/overcommit/hook/post_commit/git_guilt.rb
+++ b/lib/overcommit/hook/post_commit/git_guilt.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PostCommit
   # Calculates the change in blame since the last revision.
   #

--- a/lib/overcommit/hook/post_commit/index_tags.rb
+++ b/lib/overcommit/hook/post_commit/index_tags.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/index_tags'
 
 module Overcommit::Hook::PostCommit

--- a/lib/overcommit/hook/post_commit/npm_install.rb
+++ b/lib/overcommit/hook/post_commit/npm_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/npm_install'
 
 module Overcommit::Hook::PostCommit

--- a/lib/overcommit/hook/post_commit/submodule_status.rb
+++ b/lib/overcommit/hook/post_commit/submodule_status.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/submodule_status'
 
 module Overcommit::Hook::PostCommit

--- a/lib/overcommit/hook/post_commit/yarn_install.rb
+++ b/lib/overcommit/hook/post_commit/yarn_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/yarn_install'
 
 module Overcommit::Hook::PostCommit

--- a/lib/overcommit/hook/post_merge/base.rb
+++ b/lib/overcommit/hook/post_merge/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 
 module Overcommit::Hook::PostMerge

--- a/lib/overcommit/hook/post_merge/bower_install.rb
+++ b/lib/overcommit/hook/post_merge/bower_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/bower_install'
 
 module Overcommit::Hook::PostMerge

--- a/lib/overcommit/hook/post_merge/bundle_install.rb
+++ b/lib/overcommit/hook/post_merge/bundle_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/bundle_install'
 
 module Overcommit::Hook::PostMerge

--- a/lib/overcommit/hook/post_merge/composer_install.rb
+++ b/lib/overcommit/hook/post_merge/composer_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/composer_install'
 
 module Overcommit::Hook::PostMerge

--- a/lib/overcommit/hook/post_merge/index_tags.rb
+++ b/lib/overcommit/hook/post_merge/index_tags.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/index_tags'
 
 module Overcommit::Hook::PostMerge

--- a/lib/overcommit/hook/post_merge/npm_install.rb
+++ b/lib/overcommit/hook/post_merge/npm_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/npm_install'
 
 module Overcommit::Hook::PostMerge

--- a/lib/overcommit/hook/post_merge/submodule_status.rb
+++ b/lib/overcommit/hook/post_merge/submodule_status.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/submodule_status'
 
 module Overcommit::Hook::PostMerge

--- a/lib/overcommit/hook/post_merge/yarn_install.rb
+++ b/lib/overcommit/hook/post_merge/yarn_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/yarn_install'
 
 module Overcommit::Hook::PostMerge

--- a/lib/overcommit/hook/post_rewrite/base.rb
+++ b/lib/overcommit/hook/post_rewrite/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 
 module Overcommit::Hook::PostRewrite

--- a/lib/overcommit/hook/post_rewrite/bower_install.rb
+++ b/lib/overcommit/hook/post_rewrite/bower_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/bower_install'
 
 module Overcommit::Hook::PostRewrite

--- a/lib/overcommit/hook/post_rewrite/bundle_install.rb
+++ b/lib/overcommit/hook/post_rewrite/bundle_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/bundle_install'
 
 module Overcommit::Hook::PostRewrite

--- a/lib/overcommit/hook/post_rewrite/composer_install.rb
+++ b/lib/overcommit/hook/post_rewrite/composer_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/composer_install'
 
 module Overcommit::Hook::PostRewrite

--- a/lib/overcommit/hook/post_rewrite/index_tags.rb
+++ b/lib/overcommit/hook/post_rewrite/index_tags.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/index_tags'
 
 module Overcommit::Hook::PostRewrite

--- a/lib/overcommit/hook/post_rewrite/npm_install.rb
+++ b/lib/overcommit/hook/post_rewrite/npm_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/npm_install'
 
 module Overcommit::Hook::PostRewrite

--- a/lib/overcommit/hook/post_rewrite/submodule_status.rb
+++ b/lib/overcommit/hook/post_rewrite/submodule_status.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/submodule_status'
 
 module Overcommit::Hook::PostRewrite

--- a/lib/overcommit/hook/post_rewrite/yarn_install.rb
+++ b/lib/overcommit/hook/post_rewrite/yarn_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/yarn_install'
 
 module Overcommit::Hook::PostRewrite

--- a/lib/overcommit/hook/pre_commit/author_email.rb
+++ b/lib/overcommit/hook/pre_commit/author_email.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Checks the format of an author's email address.
   class AuthorEmail < Base

--- a/lib/overcommit/hook/pre_commit/author_name.rb
+++ b/lib/overcommit/hook/pre_commit/author_name.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Ensures that a commit author has a name with at least first and last names.
   class AuthorName < Base

--- a/lib/overcommit/hook/pre_commit/base.rb
+++ b/lib/overcommit/hook/pre_commit/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 require 'overcommit/utils/messages_utils'
 

--- a/lib/overcommit/hook/pre_commit/berksfile_check.rb
+++ b/lib/overcommit/hook/pre_commit/berksfile_check.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PreCommit
   #
   # @see http://berkshelf.com/
   class BerksfileCheck < Base
-    LOCK_FILE = 'Berksfile.lock'.freeze
+    LOCK_FILE = 'Berksfile.lock'
 
     def run
       # Ignore if Berksfile.lock is not tracked by git

--- a/lib/overcommit/hook/pre_commit/berksfile_check.rb
+++ b/lib/overcommit/hook/pre_commit/berksfile_check.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PreCommit
   #
   # @see http://berkshelf.com/
   class BerksfileCheck < Base
-    LOCK_FILE = 'Berksfile.lock'
+    LOCK_FILE = 'Berksfile.lock'.freeze
 
     def run
       # Ignore if Berksfile.lock is not tracked by git

--- a/lib/overcommit/hook/pre_commit/broken_symlinks.rb
+++ b/lib/overcommit/hook/pre_commit/broken_symlinks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Checks for broken symlinks.
   class BrokenSymlinks < Base

--- a/lib/overcommit/hook/pre_commit/bundle_audit.rb
+++ b/lib/overcommit/hook/pre_commit/bundle_audit.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Checks for vulnerable versions of gems in Gemfile.lock.
   #
   # @see https://github.com/rubysec/bundler-audit
   class BundleAudit < Base
-    LOCK_FILE = 'Gemfile.lock'.freeze
+    LOCK_FILE = 'Gemfile.lock'
 
     def run
       # Ignore if Gemfile.lock is not tracked by git

--- a/lib/overcommit/hook/pre_commit/bundle_audit.rb
+++ b/lib/overcommit/hook/pre_commit/bundle_audit.rb
@@ -5,7 +5,7 @@ module Overcommit::Hook::PreCommit
   #
   # @see https://github.com/rubysec/bundler-audit
   class BundleAudit < Base
-    LOCK_FILE = 'Gemfile.lock'
+    LOCK_FILE = 'Gemfile.lock'.freeze
 
     def run
       # Ignore if Gemfile.lock is not tracked by git

--- a/lib/overcommit/hook/pre_commit/bundle_check.rb
+++ b/lib/overcommit/hook/pre_commit/bundle_check.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PreCommit
   #
   # @see http://bundler.io/
   class BundleCheck < Base
-    LOCK_FILE = 'Gemfile.lock'.freeze
+    LOCK_FILE = 'Gemfile.lock'
 
     def run
       # Ignore if Gemfile.lock is not tracked by git

--- a/lib/overcommit/hook/pre_commit/bundle_check.rb
+++ b/lib/overcommit/hook/pre_commit/bundle_check.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PreCommit
   #
   # @see http://bundler.io/
   class BundleCheck < Base
-    LOCK_FILE = 'Gemfile.lock'
+    LOCK_FILE = 'Gemfile.lock'.freeze
 
     def run
       # Ignore if Gemfile.lock is not tracked by git

--- a/lib/overcommit/hook/pre_commit/bundle_outdated.rb
+++ b/lib/overcommit/hook/pre_commit/bundle_outdated.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Check if any gems in Gemfile.lock have newer versions, unless the
   # Gemfile.lock is ignored by Git.
   #
   # @see http://bundler.io/bundle_outdated.html
   class BundleOutdated < Base
-    LOCK_FILE = 'Gemfile.lock'.freeze
+    LOCK_FILE = 'Gemfile.lock'
 
     def run
       # Ignore if Gemfile.lock is not tracked by git

--- a/lib/overcommit/hook/pre_commit/bundle_outdated.rb
+++ b/lib/overcommit/hook/pre_commit/bundle_outdated.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PreCommit
   #
   # @see http://bundler.io/bundle_outdated.html
   class BundleOutdated < Base
-    LOCK_FILE = 'Gemfile.lock'
+    LOCK_FILE = 'Gemfile.lock'.freeze
 
     def run
       # Ignore if Gemfile.lock is not tracked by git

--- a/lib/overcommit/hook/pre_commit/case_conflicts.rb
+++ b/lib/overcommit/hook/pre_commit/case_conflicts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Checks for files that would conflict in case-insensitive filesystems
   # Adapted from https://github.com/pre-commit/pre-commit-hooks

--- a/lib/overcommit/hook/pre_commit/chamber_compare.rb
+++ b/lib/overcommit/hook/pre_commit/chamber_compare.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `chamber compare` against a configurable set of namespaces.
   #

--- a/lib/overcommit/hook/pre_commit/chamber_security.rb
+++ b/lib/overcommit/hook/pre_commit/chamber_security.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `chamber secure` against any modified Chamber settings files.
   #

--- a/lib/overcommit/hook/pre_commit/chamber_verification.rb
+++ b/lib/overcommit/hook/pre_commit/chamber_verification.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `chamber sign --verify`.
   #

--- a/lib/overcommit/hook/pre_commit/coffee_lint.rb
+++ b/lib/overcommit/hook/pre_commit/coffee_lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `coffeelint` against any modified CoffeeScript files.
   #

--- a/lib/overcommit/hook/pre_commit/credo.rb
+++ b/lib/overcommit/hook/pre_commit/credo.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `credo` against any modified ex files.
   #

--- a/lib/overcommit/hook/pre_commit/css_lint.rb
+++ b/lib/overcommit/hook/pre_commit/css_lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `csslint` against any modified CSS files.
   #

--- a/lib/overcommit/hook/pre_commit/dogma.rb
+++ b/lib/overcommit/hook/pre_commit/dogma.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `dogma` against any modified ex files.
   #

--- a/lib/overcommit/hook/pre_commit/es_lint.rb
+++ b/lib/overcommit/hook/pre_commit/es_lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `eslint` against any modified JavaScript files.
   #

--- a/lib/overcommit/hook/pre_commit/execute_permissions.rb
+++ b/lib/overcommit/hook/pre_commit/execute_permissions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Checks for files with execute permissions, which are usually not necessary
   # in source code files (and are typically caused by a misconfigured editor

--- a/lib/overcommit/hook/pre_commit/fasterer.rb
+++ b/lib/overcommit/hook/pre_commit/fasterer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `fasterer` against any modified Ruby files.
   #

--- a/lib/overcommit/hook/pre_commit/fix_me.rb
+++ b/lib/overcommit/hook/pre_commit/fix_me.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Check for "token" strings
   class FixMe < Base

--- a/lib/overcommit/hook/pre_commit/flay.rb
+++ b/lib/overcommit/hook/pre_commit/flay.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `flay` against any modified files.
   #

--- a/lib/overcommit/hook/pre_commit/foodcritic.rb
+++ b/lib/overcommit/hook/pre_commit/foodcritic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `foodcritic` against any modified Ruby files from Chef directory structure.
   #

--- a/lib/overcommit/hook/pre_commit/forbidden_branches.rb
+++ b/lib/overcommit/hook/pre_commit/forbidden_branches.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Prevents commits to branches matching one of the configured patterns.
   class ForbiddenBranches < Base

--- a/lib/overcommit/hook/pre_commit/go_lint.rb
+++ b/lib/overcommit/hook/pre_commit/go_lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `golint` against any modified Golang files.
   #

--- a/lib/overcommit/hook/pre_commit/go_vet.rb
+++ b/lib/overcommit/hook/pre_commit/go_vet.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `go vet` against any modified Golang files.
   #

--- a/lib/overcommit/hook/pre_commit/hadolint.rb
+++ b/lib/overcommit/hook/pre_commit/hadolint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `hadolint` against any modified Dockefile files.
   #

--- a/lib/overcommit/hook/pre_commit/haml_lint.rb
+++ b/lib/overcommit/hook/pre_commit/haml_lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `haml-lint` against any modified HAML files.
   #

--- a/lib/overcommit/hook/pre_commit/hard_tabs.rb
+++ b/lib/overcommit/hook/pre_commit/hard_tabs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Checks for hard tabs in files.
   class HardTabs < Base

--- a/lib/overcommit/hook/pre_commit/hlint.rb
+++ b/lib/overcommit/hook/pre_commit/hlint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `hlint` against any modified Haskell files.
   #

--- a/lib/overcommit/hook/pre_commit/html_hint.rb
+++ b/lib/overcommit/hook/pre_commit/html_hint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `htmlhint` against any modified HTML files.
   #

--- a/lib/overcommit/hook/pre_commit/html_tidy.rb
+++ b/lib/overcommit/hook/pre_commit/html_tidy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `tidy` against any modified HTML files.
   #

--- a/lib/overcommit/hook/pre_commit/image_optim.rb
+++ b/lib/overcommit/hook/pre_commit/image_optim.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Checks for images that can be optimized with `image_optim`.
   #

--- a/lib/overcommit/hook/pre_commit/java_checkstyle.rb
+++ b/lib/overcommit/hook/pre_commit/java_checkstyle.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `checkstyle` against any modified Java files.
   #

--- a/lib/overcommit/hook/pre_commit/js_hint.rb
+++ b/lib/overcommit/hook/pre_commit/js_hint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `jshint` against any modified JavaScript files.
   #

--- a/lib/overcommit/hook/pre_commit/js_lint.rb
+++ b/lib/overcommit/hook/pre_commit/js_lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `jslint` against any modified JavaScript files.
   #

--- a/lib/overcommit/hook/pre_commit/jscs.rb
+++ b/lib/overcommit/hook/pre_commit/jscs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `jscs` (JavaScript Code Style Checker) against any modified JavaScript
   # files.

--- a/lib/overcommit/hook/pre_commit/jsl.rb
+++ b/lib/overcommit/hook/pre_commit/jsl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `jsl` against any modified JavaScript files.
   #

--- a/lib/overcommit/hook/pre_commit/json_syntax.rb
+++ b/lib/overcommit/hook/pre_commit/json_syntax.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Checks the syntax of any modified JSON files.
   class JsonSyntax < Base

--- a/lib/overcommit/hook/pre_commit/kt_lint.rb
+++ b/lib/overcommit/hook/pre_commit/kt_lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `ktlint` against modified Kotlin files.
   # @see https://github.com/shyiko/ktlint

--- a/lib/overcommit/hook/pre_commit/license_finder.rb
+++ b/lib/overcommit/hook/pre_commit/license_finder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs LicenseFinder if any of your package manager declaration files have changed
   # See more about LicenseFinder at https://github.com/pivotal/LicenseFinder

--- a/lib/overcommit/hook/pre_commit/license_header.rb
+++ b/lib/overcommit/hook/pre_commit/license_header.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Checks for license headers in source files
   class LicenseHeader < Base

--- a/lib/overcommit/hook/pre_commit/line_endings.rb
+++ b/lib/overcommit/hook/pre_commit/line_endings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Checks for line endings in files.
   #

--- a/lib/overcommit/hook/pre_commit/local_paths_in_gemfile.rb
+++ b/lib/overcommit/hook/pre_commit/local_paths_in_gemfile.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Checks for local paths in files and issues a warning
   class LocalPathsInGemfile < Base

--- a/lib/overcommit/hook/pre_commit/mdl.rb
+++ b/lib/overcommit/hook/pre_commit/mdl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `mdl` against any modified Markdown files
   #

--- a/lib/overcommit/hook/pre_commit/merge_conflicts.rb
+++ b/lib/overcommit/hook/pre_commit/merge_conflicts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Checks for unresolved merge conflicts
   class MergeConflicts < Base

--- a/lib/overcommit/hook/pre_commit/nginx_test.rb
+++ b/lib/overcommit/hook/pre_commit/nginx_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `nginx -t` against any modified Nginx config files.
   #

--- a/lib/overcommit/hook/pre_commit/pep257.rb
+++ b/lib/overcommit/hook/pre_commit/pep257.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `pep257` against any modified Python files.
   #

--- a/lib/overcommit/hook/pre_commit/pep8.rb
+++ b/lib/overcommit/hook/pre_commit/pep8.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `pep8` against any modified Python files.
   #

--- a/lib/overcommit/hook/pre_commit/php_cs.rb
+++ b/lib/overcommit/hook/pre_commit/php_cs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `phpcs` against any modified PHP files.
   class PhpCs < Base

--- a/lib/overcommit/hook/pre_commit/php_cs_fixer.rb
+++ b/lib/overcommit/hook/pre_commit/php_cs_fixer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `php-cs-fixer` against any modified PHP files.
   class PhpCsFixer < Base

--- a/lib/overcommit/hook/pre_commit/php_lint.rb
+++ b/lib/overcommit/hook/pre_commit/php_lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `php -l` against any modified PHP files.
   class PhpLint < Base

--- a/lib/overcommit/hook/pre_commit/php_stan.rb
+++ b/lib/overcommit/hook/pre_commit/php_stan.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `phpstan` against any modified PHP files.
   # For running `phpstan` with Laravel, it requires setup with `ide_helper`.

--- a/lib/overcommit/hook/pre_commit/pronto.rb
+++ b/lib/overcommit/hook/pre_commit/pronto.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `pronto`
   #

--- a/lib/overcommit/hook/pre_commit/puppet_lint.rb
+++ b/lib/overcommit/hook/pre_commit/puppet_lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs 'puppet-lint' against any modified Puppet files.
   #

--- a/lib/overcommit/hook/pre_commit/puppet_metadata_json_lint.rb
+++ b/lib/overcommit/hook/pre_commit/puppet_metadata_json_lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   #
   # Run's the Puppet metadata linter. It has support for adding options

--- a/lib/overcommit/hook/pre_commit/pycodestyle.rb
+++ b/lib/overcommit/hook/pre_commit/pycodestyle.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `pycodestyle` against any modified Python files.
   #

--- a/lib/overcommit/hook/pre_commit/pydocstyle.rb
+++ b/lib/overcommit/hook/pre_commit/pydocstyle.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `pydocstyle` against any modified Python files.
   #

--- a/lib/overcommit/hook/pre_commit/pyflakes.rb
+++ b/lib/overcommit/hook/pre_commit/pyflakes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `pyflakes` against any modified Python files.
   #

--- a/lib/overcommit/hook/pre_commit/pylint.rb
+++ b/lib/overcommit/hook/pre_commit/pylint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `pylint` against any modified Python files.
   #

--- a/lib/overcommit/hook/pre_commit/python_flake8.rb
+++ b/lib/overcommit/hook/pre_commit/python_flake8.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `flake8` against any modified Python files.
   #

--- a/lib/overcommit/hook/pre_commit/rails_best_practices.rb
+++ b/lib/overcommit/hook/pre_commit/rails_best_practices.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit
   module Hook
     module PreCommit

--- a/lib/overcommit/hook/pre_commit/rails_schema_up_to_date.rb
+++ b/lib/overcommit/hook/pre_commit/rails_schema_up_to_date.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Check to see whether the schema file is in line with the migrations. When a
   # schema file is present but a migration file is not, this is usually a

--- a/lib/overcommit/hook/pre_commit/rake_target.rb
+++ b/lib/overcommit/hook/pre_commit/rake_target.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/rake_target'
 
 module Overcommit::Hook::PreCommit

--- a/lib/overcommit/hook/pre_commit/reek.rb
+++ b/lib/overcommit/hook/pre_commit/reek.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `reek` against any modified Ruby files.
   #

--- a/lib/overcommit/hook/pre_commit/rst_lint.rb
+++ b/lib/overcommit/hook/pre_commit/rst_lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `rst-lint` against any modified reStructuredText files
   #

--- a/lib/overcommit/hook/pre_commit/rubo_cop.rb
+++ b/lib/overcommit/hook/pre_commit/rubo_cop.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `rubocop` against any modified Ruby files.
   #

--- a/lib/overcommit/hook/pre_commit/ruby_lint.rb
+++ b/lib/overcommit/hook/pre_commit/ruby_lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `ruby-lint` against any modified Ruby files.
   #

--- a/lib/overcommit/hook/pre_commit/scalariform.rb
+++ b/lib/overcommit/hook/pre_commit/scalariform.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `scalariform` against any modified Scala files.
   #

--- a/lib/overcommit/hook/pre_commit/scalastyle.rb
+++ b/lib/overcommit/hook/pre_commit/scalastyle.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `scalastyle` against any modified Scala files.
   #

--- a/lib/overcommit/hook/pre_commit/scss_lint.rb
+++ b/lib/overcommit/hook/pre_commit/scss_lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `scss-lint` against any modified SCSS files.
   #

--- a/lib/overcommit/hook/pre_commit/semi_standard.rb
+++ b/lib/overcommit/hook/pre_commit/semi_standard.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `semistandard` against any modified JavaScript files.
   #

--- a/lib/overcommit/hook/pre_commit/shell_check.rb
+++ b/lib/overcommit/hook/pre_commit/shell_check.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `shellcheck` against any modified shell script files.
   #

--- a/lib/overcommit/hook/pre_commit/slim_lint.rb
+++ b/lib/overcommit/hook/pre_commit/slim_lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `slim-lint` against any modified Slim templates.
   #

--- a/lib/overcommit/hook/pre_commit/sqlint.rb
+++ b/lib/overcommit/hook/pre_commit/sqlint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs 'sqlint' against any modified SQL files.
   #

--- a/lib/overcommit/hook/pre_commit/standard.rb
+++ b/lib/overcommit/hook/pre_commit/standard.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `standard` against any modified JavaScript files.
   #

--- a/lib/overcommit/hook/pre_commit/stylelint.rb
+++ b/lib/overcommit/hook/pre_commit/stylelint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `stylelint` against any modified CSS file.
   #

--- a/lib/overcommit/hook/pre_commit/swift_lint.rb
+++ b/lib/overcommit/hook/pre_commit/swift_lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `swiftlint lint` against modified Swift files.
   # @see https://github.com/realm/SwiftLint

--- a/lib/overcommit/hook/pre_commit/trailing_whitespace.rb
+++ b/lib/overcommit/hook/pre_commit/trailing_whitespace.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Checks for trailing whitespace in files.
   class TrailingWhitespace < Base

--- a/lib/overcommit/hook/pre_commit/travis_lint.rb
+++ b/lib/overcommit/hook/pre_commit/travis_lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `travis-lint` against any modified Travis CI files.
   #

--- a/lib/overcommit/hook/pre_commit/ts_lint.rb
+++ b/lib/overcommit/hook/pre_commit/ts_lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `tslint` against modified TypeScript files.
   # @see http://palantir.github.io/tslint/

--- a/lib/overcommit/hook/pre_commit/vint.rb
+++ b/lib/overcommit/hook/pre_commit/vint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `vint` against any modified Vim script files.
   #

--- a/lib/overcommit/hook/pre_commit/w3c_css.rb
+++ b/lib/overcommit/hook/pre_commit/w3c_css.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `w3c_validators` against any modified CSS files.
   #

--- a/lib/overcommit/hook/pre_commit/w3c_html.rb
+++ b/lib/overcommit/hook/pre_commit/w3c_html.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `w3c_validators` against any modified HTML files.
   #

--- a/lib/overcommit/hook/pre_commit/xml_lint.rb
+++ b/lib/overcommit/hook/pre_commit/xml_lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `xmllint` against any modified XML files.
   #

--- a/lib/overcommit/hook/pre_commit/xml_syntax.rb
+++ b/lib/overcommit/hook/pre_commit/xml_syntax.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Checks the syntax of any modified XML files.
   class XmlSyntax < Base

--- a/lib/overcommit/hook/pre_commit/yaml_lint.rb
+++ b/lib/overcommit/hook/pre_commit/yaml_lint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Runs `YAMLLint` against any modified YAML files.
   #

--- a/lib/overcommit/hook/pre_commit/yaml_syntax.rb
+++ b/lib/overcommit/hook/pre_commit/yaml_syntax.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Checks the syntax of any modified YAML files.
   class YamlSyntax < Base

--- a/lib/overcommit/hook/pre_commit/yard_coverage.rb
+++ b/lib/overcommit/hook/pre_commit/yard_coverage.rb
@@ -1,4 +1,6 @@
 
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreCommit
   # Class to check yard documentation coverage.
   #

--- a/lib/overcommit/hook/pre_commit/yarn_check.rb
+++ b/lib/overcommit/hook/pre_commit/yarn_check.rb
@@ -6,13 +6,13 @@ module Overcommit::Hook::PreCommit
   #
   # @see https://yarnpkg.com/en/docs/cli/check
   class YarnCheck < Base
-    LOCK_FILE = 'yarn.lock'.freeze
+    LOCK_FILE = 'yarn.lock'
 
     # A lot of the errors returned by `yarn check` are outside the developer's control
     # (are caused by bad package specification, in the hands of the upstream maintainer)
     # So limit reporting to errors the developer can do something about
     ACTIONABLE_ERRORS = [
-      'Lockfile does not contain pattern'.freeze,
+      'Lockfile does not contain pattern',
     ].freeze
 
     def run

--- a/lib/overcommit/hook/pre_commit/yarn_check.rb
+++ b/lib/overcommit/hook/pre_commit/yarn_check.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PreCommit
   #
   # @see https://yarnpkg.com/en/docs/cli/check
   class YarnCheck < Base
-    LOCK_FILE = 'yarn.lock'
+    LOCK_FILE = 'yarn.lock'.freeze
 
     # A lot of the errors returned by `yarn check` are outside the developer's control
     # (are caused by bad package specification, in the hands of the upstream maintainer)

--- a/lib/overcommit/hook/pre_push/base.rb
+++ b/lib/overcommit/hook/pre_push/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 
 module Overcommit::Hook::PrePush

--- a/lib/overcommit/hook/pre_push/brakeman.rb
+++ b/lib/overcommit/hook/pre_push/brakeman.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PrePush
   # Runs `brakeman` whenever Ruby/Rails files change.
   #

--- a/lib/overcommit/hook/pre_push/cargo_test.rb
+++ b/lib/overcommit/hook/pre_push/cargo_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PrePush
   # Runs `cargo test` before push if Rust files changed
   class CargoTest < Base

--- a/lib/overcommit/hook/pre_push/minitest.rb
+++ b/lib/overcommit/hook/pre_push/minitest.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PrePush
   # Runs `minitest` test suite before push
   #

--- a/lib/overcommit/hook/pre_push/php_unit.rb
+++ b/lib/overcommit/hook/pre_push/php_unit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PrePush
   # Runs `phpunit` test suite before push
   #

--- a/lib/overcommit/hook/pre_push/protected_branches.rb
+++ b/lib/overcommit/hook/pre_push/protected_branches.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PrePush
   # Prevents destructive updates to specified branches.
   class ProtectedBranches < Base

--- a/lib/overcommit/hook/pre_push/pytest.rb
+++ b/lib/overcommit/hook/pre_push/pytest.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PrePush
   # Runs `pytest` test suite before push
   #

--- a/lib/overcommit/hook/pre_push/python_nose.rb
+++ b/lib/overcommit/hook/pre_push/python_nose.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PrePush
   # Runs `nose` test suite before push
   #

--- a/lib/overcommit/hook/pre_push/r_spec.rb
+++ b/lib/overcommit/hook/pre_push/r_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PrePush
   # Runs `rspec` test suite before push
   #

--- a/lib/overcommit/hook/pre_push/rake_target.rb
+++ b/lib/overcommit/hook/pre_push/rake_target.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/hook/shared/rake_target'
 
 module Overcommit::Hook::PrePush

--- a/lib/overcommit/hook/pre_push/test_unit.rb
+++ b/lib/overcommit/hook/pre_push/test_unit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PrePush
   # Runs `test-unit` test suite before push
   #

--- a/lib/overcommit/hook/pre_rebase/base.rb
+++ b/lib/overcommit/hook/pre_rebase/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 
 module Overcommit::Hook::PreRebase

--- a/lib/overcommit/hook/pre_rebase/merged_commits.rb
+++ b/lib/overcommit/hook/pre_rebase/merged_commits.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PreRebase
   # Prevents rebasing commits that have already been merged into one of
   # a specified set of branches.

--- a/lib/overcommit/hook/prepare_commit_msg/base.rb
+++ b/lib/overcommit/hook/prepare_commit_msg/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 
 module Overcommit::Hook::PrepareCommitMsg

--- a/lib/overcommit/hook/prepare_commit_msg/replace_branch.rb
+++ b/lib/overcommit/hook/prepare_commit_msg/replace_branch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::PrepareCommitMsg
   # Prepends the commit message with a message based on the branch name.
   # It's possible to reference parts of the branch name through the captures in

--- a/lib/overcommit/hook/shared/bower_install.rb
+++ b/lib/overcommit/hook/shared/bower_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::Shared
   # Shared code used by all BowerInstall hooks. Runs `bower install` when a
   # change is detected in the repository's dependencies.

--- a/lib/overcommit/hook/shared/bundle_install.rb
+++ b/lib/overcommit/hook/shared/bundle_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::Shared
   # Shared code used by all BundleInstall hooks. Runs `bundle install` when a
   # change is detected in the repository's dependencies.

--- a/lib/overcommit/hook/shared/composer_install.rb
+++ b/lib/overcommit/hook/shared/composer_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::Shared
   # Shared code used by all ComposerInstall hooks. Runs `composer install` when
   # a change is detected in the repository's dependencies.

--- a/lib/overcommit/hook/shared/index_tags.rb
+++ b/lib/overcommit/hook/shared/index_tags.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::Shared
   # Shared code used by all IndexTags hooks. It runs ctags in the background so
   # your tag definitions are up-to-date.

--- a/lib/overcommit/hook/shared/npm_install.rb
+++ b/lib/overcommit/hook/shared/npm_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::Shared
   # Shared code used by all NpmInstall hooks. Runs `npm install` when a change
   # is detected in the repository's dependencies.

--- a/lib/overcommit/hook/shared/rake_target.rb
+++ b/lib/overcommit/hook/shared/rake_target.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::Shared
   # runs specified rake targets. It fails on the first non-
   # successfull exit.

--- a/lib/overcommit/hook/shared/submodule_status.rb
+++ b/lib/overcommit/hook/shared/submodule_status.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::Shared
   # Shared code used by all `SubmoduleStatus` hooks to notify the user if any
   # submodules are uninitialized, out of date with the current index, or contain

--- a/lib/overcommit/hook/shared/yarn_install.rb
+++ b/lib/overcommit/hook/shared/yarn_install.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Hook::Shared
   # Shared code used by all YarnInstall hooks. Runs `yarn install` when a change
   # is detected in the repository's dependencies.

--- a/lib/overcommit/hook_context.rb
+++ b/lib/overcommit/hook_context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Utility module which manages the creation of {HookContext}s.
 module Overcommit::HookContext
   def self.create(hook_type, config, args, input)

--- a/lib/overcommit/hook_context/base.rb
+++ b/lib/overcommit/hook_context/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::HookContext
   # Contains helpers related to the context with which a hook is being run.
   #

--- a/lib/overcommit/hook_context/commit_msg.rb
+++ b/lib/overcommit/hook_context/commit_msg.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::HookContext
   # Contains helpers related to contextual information used by commit-msg hooks.
   class CommitMsg < Base

--- a/lib/overcommit/hook_context/post_checkout.rb
+++ b/lib/overcommit/hook_context/post_checkout.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::HookContext
   # Contains helpers related to contextual information used by post-checkout
   # hooks.

--- a/lib/overcommit/hook_context/post_commit.rb
+++ b/lib/overcommit/hook_context/post_commit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::HookContext
   # Contains helpers related to contextual information used by post-commit
   # hooks.

--- a/lib/overcommit/hook_context/post_merge.rb
+++ b/lib/overcommit/hook_context/post_merge.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::HookContext
   # Contains helpers related to contextual information used by post-merge
   # hooks.

--- a/lib/overcommit/hook_context/post_rewrite.rb
+++ b/lib/overcommit/hook_context/post_rewrite.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::HookContext
   # Contains helpers for contextual information used by post-rewrite hooks.
   class PostRewrite < Base

--- a/lib/overcommit/hook_context/pre_commit.rb
+++ b/lib/overcommit/hook_context/pre_commit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 require 'set'
 
@@ -19,7 +21,8 @@ module Overcommit::HookContext
       # containing unicode characters, we replace the offending characters,
       # since the pattern we're looking for will consist of ASCII characters
       unless cmd.valid_encoding?
-        cmd.encode!('UTF-16be', invalid: :replace, replace: '?').encode!('UTF-8')
+        cmd = Overcommit::Utils.parent_command.encode('UTF-16be', invalid: :replace, replace: '?')
+                               .encode('UTF-8')
       end
 
       return @amendment if

--- a/lib/overcommit/hook_context/pre_commit.rb
+++ b/lib/overcommit/hook_context/pre_commit.rb
@@ -21,8 +21,8 @@ module Overcommit::HookContext
       # containing unicode characters, we replace the offending characters,
       # since the pattern we're looking for will consist of ASCII characters
       unless cmd.valid_encoding?
-        cmd = Overcommit::Utils.parent_command.encode('UTF-16be', invalid: :replace, replace: '?')
-                               .encode('UTF-8')
+        cmd = Overcommit::Utils.parent_command.encode('UTF-16be', invalid: :replace, replace: '?').
+                                               encode('UTF-8')
       end
 
       return @amendment if

--- a/lib/overcommit/hook_context/pre_push.rb
+++ b/lib/overcommit/hook_context/pre_push.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::HookContext
   # Contains helpers related to contextual information used by pre-push hooks.
   class PrePush < Base

--- a/lib/overcommit/hook_context/pre_rebase.rb
+++ b/lib/overcommit/hook_context/pre_rebase.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::HookContext
   # Contains helpers related to contextual information used by pre-rebase
   # hooks.

--- a/lib/overcommit/hook_context/prepare_commit_msg.rb
+++ b/lib/overcommit/hook_context/prepare_commit_msg.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::HookContext
   # Contains helpers related to contextual information used by prepare-commit-msg
   # hooks.
@@ -14,7 +16,7 @@ module Overcommit::HookContext
     # exists); or commit, followed by a commit SHA-1 (if a -c, -C or --amend
     # option was given)
     def commit_message_source
-      @args[1].to_sym if @args[1]
+      @args[1]&.to_sym
     end
 
     # Returns the commit's SHA-1.

--- a/lib/overcommit/hook_context/prepare_commit_msg.rb
+++ b/lib/overcommit/hook_context/prepare_commit_msg.rb
@@ -16,7 +16,7 @@ module Overcommit::HookContext
     # exists); or commit, followed by a commit SHA-1 (if a -c, -C or --amend
     # option was given)
     def commit_message_source
-      @args[1]&.to_sym
+      @args[1].to_sym if @args[1]
     end
 
     # Returns the commit's SHA-1.

--- a/lib/overcommit/hook_context/run_all.rb
+++ b/lib/overcommit/hook_context/run_all.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module Overcommit::HookContext

--- a/lib/overcommit/hook_loader/base.rb
+++ b/lib/overcommit/hook_loader/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::HookLoader
   # Responsible for loading hooks from a file.
   class Base

--- a/lib/overcommit/hook_loader/built_in_hook_loader.rb
+++ b/lib/overcommit/hook_loader/built_in_hook_loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::HookLoader
   # Responsible for loading hooks that ship with Overcommit.
   class BuiltInHookLoader < Base

--- a/lib/overcommit/hook_loader/plugin_hook_loader.rb
+++ b/lib/overcommit/hook_loader/plugin_hook_loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'digest'
 
 module Overcommit::HookLoader

--- a/lib/overcommit/hook_runner.rb
+++ b/lib/overcommit/hook_runner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit
   # Responsible for loading the hooks the repository has configured and running
   # them, collecting and displaying the results.

--- a/lib/overcommit/hook_signer.rb
+++ b/lib/overcommit/hook_signer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit
   # Calculates, stores, and retrieves stored signatures of hook plugins.
   class HookSigner

--- a/lib/overcommit/installer.rb
+++ b/lib/overcommit/installer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 
 module Overcommit

--- a/lib/overcommit/interrupt_handler.rb
+++ b/lib/overcommit/interrupt_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'singleton'
 
 # Provides a handler for interrupt signals (SIGINT), allowing the application to

--- a/lib/overcommit/logger.rb
+++ b/lib/overcommit/logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit
   # Encapsulates all communication to an output source.
   class Logger

--- a/lib/overcommit/message_processor.rb
+++ b/lib/overcommit/message_processor.rb
@@ -8,12 +8,12 @@ module Overcommit
   # output tuple from an array of {Overcommit::Hook::Message}s, respecting the
   # configuration settings for the given hook.
   class MessageProcessor
-    ERRORS_MODIFIED_HEADER = 'Errors on modified lines:'
-    WARNINGS_MODIFIED_HEADER = 'Warnings on modified lines:'
-    ERRORS_UNMODIFIED_HEADER = "Errors on lines you didn't modify:"
-    WARNINGS_UNMODIFIED_HEADER = "Warnings on lines you didn't modify:"
-    ERRORS_GENERIC_HEADER = 'Errors:'
-    WARNINGS_GENERIC_HEADER = 'Warnings:'
+    ERRORS_MODIFIED_HEADER = 'Errors on modified lines:'.freeze
+    WARNINGS_MODIFIED_HEADER = 'Warnings on modified lines:'.freeze
+    ERRORS_UNMODIFIED_HEADER = "Errors on lines you didn't modify:".freeze
+    WARNINGS_UNMODIFIED_HEADER = "Warnings on lines you didn't modify:".freeze
+    ERRORS_GENERIC_HEADER = 'Errors:'.freeze
+    WARNINGS_GENERIC_HEADER = 'Warnings:'.freeze
 
     # @param hook [Overcommit::Hook::Base]
     # @param unmodified_lines_setting [String] how to treat messages on

--- a/lib/overcommit/message_processor.rb
+++ b/lib/overcommit/message_processor.rb
@@ -8,12 +8,12 @@ module Overcommit
   # output tuple from an array of {Overcommit::Hook::Message}s, respecting the
   # configuration settings for the given hook.
   class MessageProcessor
-    ERRORS_MODIFIED_HEADER = 'Errors on modified lines:'.freeze
-    WARNINGS_MODIFIED_HEADER = 'Warnings on modified lines:'.freeze
-    ERRORS_UNMODIFIED_HEADER = "Errors on lines you didn't modify:".freeze
-    WARNINGS_UNMODIFIED_HEADER = "Warnings on lines you didn't modify:".freeze
-    ERRORS_GENERIC_HEADER = 'Errors:'.freeze
-    WARNINGS_GENERIC_HEADER = 'Warnings:'.freeze
+    ERRORS_MODIFIED_HEADER = 'Errors on modified lines:'
+    WARNINGS_MODIFIED_HEADER = 'Warnings on modified lines:'
+    ERRORS_UNMODIFIED_HEADER = "Errors on lines you didn't modify:"
+    WARNINGS_UNMODIFIED_HEADER = "Warnings on lines you didn't modify:"
+    ERRORS_GENERIC_HEADER = 'Errors:'
+    WARNINGS_GENERIC_HEADER = 'Warnings:'
 
     # @param hook [Overcommit::Hook::Base]
     # @param unmodified_lines_setting [String] how to treat messages on

--- a/lib/overcommit/os.rb
+++ b/lib/overcommit/os.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rbconfig'
 
 module Overcommit

--- a/lib/overcommit/printer.rb
+++ b/lib/overcommit/printer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'monitor'
 
 module Overcommit

--- a/lib/overcommit/subprocess.rb
+++ b/lib/overcommit/subprocess.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'childprocess'
 require 'tempfile'
 

--- a/lib/overcommit/utils.rb
+++ b/lib/overcommit/utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require 'overcommit/os'
 require 'overcommit/subprocess'
@@ -295,7 +297,7 @@ module Overcommit
       #
       # @param args [Array<String>]
       def debug(*args)
-        log.debug(*args) if log
+        log&.debug(*args)
       end
     end
   end

--- a/lib/overcommit/utils.rb
+++ b/lib/overcommit/utils.rb
@@ -297,7 +297,7 @@ module Overcommit
       #
       # @param args [Array<String>]
       def debug(*args)
-        log&.debug(*args)
+        log.debug(*args) if log
       end
     end
   end

--- a/lib/overcommit/utils/file_utils.rb
+++ b/lib/overcommit/utils/file_utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'overcommit/os'
 require 'overcommit/subprocess'
 

--- a/lib/overcommit/utils/messages_utils.rb
+++ b/lib/overcommit/utils/messages_utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Overcommit::Utils
   # Utility to process messages
   module MessagesUtils

--- a/lib/overcommit/version.rb
+++ b/lib/overcommit/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the gem version.
 module Overcommit
-  VERSION = '0.46.0'.freeze
+  VERSION = '0.46.0'
 end

--- a/lib/overcommit/version.rb
+++ b/lib/overcommit/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the gem version.
 module Overcommit
-  VERSION = '0.46.0'
+  VERSION = '0.46.0'.freeze
 end

--- a/spec/integration/committing_spec.rb
+++ b/spec/integration/committing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'commiting' do

--- a/spec/integration/configuration_signing_spec.rb
+++ b/spec/integration/configuration_signing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'yaml'
 

--- a/spec/integration/disable_overcommit_spec.rb
+++ b/spec/integration/disable_overcommit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'disabling Overcommit' do

--- a/spec/integration/gemfile_option_spec.rb
+++ b/spec/integration/gemfile_option_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'specifying `gemfile` option in Overcommit configuration' do

--- a/spec/integration/hook_signing_spec.rb
+++ b/spec/integration/hook_signing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'yaml'
 

--- a/spec/integration/installing_overcommit_spec.rb
+++ b/spec/integration/installing_overcommit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'installing Overcommit' do

--- a/spec/integration/parallelize_spec.rb
+++ b/spec/integration/parallelize_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'timeout'
 

--- a/spec/integration/protected_branches_spec.rb
+++ b/spec/integration/protected_branches_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PrePush::ProtectedBranches,

--- a/spec/integration/resolving_cherry_pick_conflict_spec.rb
+++ b/spec/integration/resolving_cherry_pick_conflict_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'resolving cherry-pick conflicts' do

--- a/spec/integration/resolving_merge_conflict_spec.rb
+++ b/spec/integration/resolving_merge_conflict_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'resolving merge conflicts' do

--- a/spec/integration/run_flag_spec.rb
+++ b/spec/integration/run_flag_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'overcommit --run' do

--- a/spec/integration/template_dir_spec.rb
+++ b/spec/integration/template_dir_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'fileutils'
 

--- a/spec/overcommit/cli_spec.rb
+++ b/spec/overcommit/cli_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'overcommit/cli'
 require 'overcommit/hook_context/run_all'

--- a/spec/overcommit/command_splitter_spec.rb
+++ b/spec/overcommit/command_splitter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::CommandSplitter do

--- a/spec/overcommit/configuration_loader_spec.rb
+++ b/spec/overcommit/configuration_loader_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::ConfigurationLoader do

--- a/spec/overcommit/configuration_spec.rb
+++ b/spec/overcommit/configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Configuration do

--- a/spec/overcommit/configuration_validator_spec.rb
+++ b/spec/overcommit/configuration_validator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::ConfigurationValidator do

--- a/spec/overcommit/default_configuration_spec.rb
+++ b/spec/overcommit/default_configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'default configuration' do

--- a/spec/overcommit/git_config_spec.rb
+++ b/spec/overcommit/git_config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::GitConfig do

--- a/spec/overcommit/git_repo_spec.rb
+++ b/spec/overcommit/git_repo_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::GitRepo do

--- a/spec/overcommit/hook/base_spec.rb
+++ b/spec/overcommit/hook/base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::Base do

--- a/spec/overcommit/hook/commit_msg/capitalized_subject_spec.rb
+++ b/spec/overcommit/hook/commit_msg/capitalized_subject_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::CommitMsg::CapitalizedSubject do

--- a/spec/overcommit/hook/commit_msg/empty_message_spec.rb
+++ b/spec/overcommit/hook/commit_msg/empty_message_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::CommitMsg::EmptyMessage do

--- a/spec/overcommit/hook/commit_msg/gerrit_change_id_spec.rb
+++ b/spec/overcommit/hook/commit_msg/gerrit_change_id_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::CommitMsg::GerritChangeId do

--- a/spec/overcommit/hook/commit_msg/hard_tabs_spec.rb
+++ b/spec/overcommit/hook/commit_msg/hard_tabs_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::CommitMsg::HardTabs do

--- a/spec/overcommit/hook/commit_msg/message_format_spec.rb
+++ b/spec/overcommit/hook/commit_msg/message_format_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::CommitMsg::MessageFormat do

--- a/spec/overcommit/hook/commit_msg/russian_novel_spec.rb
+++ b/spec/overcommit/hook/commit_msg/russian_novel_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::CommitMsg::RussianNovel do

--- a/spec/overcommit/hook/commit_msg/single_line_subject_spec.rb
+++ b/spec/overcommit/hook/commit_msg/single_line_subject_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::CommitMsg::SingleLineSubject do

--- a/spec/overcommit/hook/commit_msg/spell_check_spec.rb
+++ b/spec/overcommit/hook/commit_msg/spell_check_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::CommitMsg::SpellCheck do

--- a/spec/overcommit/hook/commit_msg/text_width_spec.rb
+++ b/spec/overcommit/hook/commit_msg/text_width_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::CommitMsg::TextWidth do

--- a/spec/overcommit/hook/commit_msg/trailing_period_spec.rb
+++ b/spec/overcommit/hook/commit_msg/trailing_period_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::CommitMsg::TrailingPeriod do

--- a/spec/overcommit/hook/post_checkout/base_spec.rb
+++ b/spec/overcommit/hook/post_checkout/base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostCheckout::Base do

--- a/spec/overcommit/hook/post_checkout/bower_install_spec.rb
+++ b/spec/overcommit/hook/post_checkout/bower_install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostCheckout::BowerInstall do

--- a/spec/overcommit/hook/post_checkout/bundle_install_spec.rb
+++ b/spec/overcommit/hook/post_checkout/bundle_install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostCheckout::BundleInstall do

--- a/spec/overcommit/hook/post_checkout/composer_install_spec.rb
+++ b/spec/overcommit/hook/post_checkout/composer_install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostCheckout::ComposerInstall do

--- a/spec/overcommit/hook/post_checkout/index_tags_spec.rb
+++ b/spec/overcommit/hook/post_checkout/index_tags_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostCheckout::IndexTags do

--- a/spec/overcommit/hook/post_checkout/npm_install_spec.rb
+++ b/spec/overcommit/hook/post_checkout/npm_install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostCheckout::NpmInstall do

--- a/spec/overcommit/hook/post_checkout/submodule_status_spec.rb
+++ b/spec/overcommit/hook/post_checkout/submodule_status_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostCheckout::SubmoduleStatus do

--- a/spec/overcommit/hook/post_checkout/yarn_install_spec.rb
+++ b/spec/overcommit/hook/post_checkout/yarn_install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostCheckout::YarnInstall do

--- a/spec/overcommit/hook/post_commit/bower_install_spec.rb
+++ b/spec/overcommit/hook/post_commit/bower_install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostCommit::BowerInstall do

--- a/spec/overcommit/hook/post_commit/bundle_install_spec.rb
+++ b/spec/overcommit/hook/post_commit/bundle_install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostCommit::BundleInstall do

--- a/spec/overcommit/hook/post_commit/commitplease_spec.rb
+++ b/spec/overcommit/hook/post_commit/commitplease_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostCommit::Commitplease do

--- a/spec/overcommit/hook/post_commit/composer_install_spec.rb
+++ b/spec/overcommit/hook/post_commit/composer_install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostCommit::ComposerInstall do

--- a/spec/overcommit/hook/post_commit/git_guilt_spec.rb
+++ b/spec/overcommit/hook/post_commit/git_guilt_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostCommit::GitGuilt do

--- a/spec/overcommit/hook/post_commit/index_tags_spec.rb
+++ b/spec/overcommit/hook/post_commit/index_tags_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostCommit::IndexTags do

--- a/spec/overcommit/hook/post_commit/npm_install_spec.rb
+++ b/spec/overcommit/hook/post_commit/npm_install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostCommit::NpmInstall do

--- a/spec/overcommit/hook/post_commit/submodule_status_spec.rb
+++ b/spec/overcommit/hook/post_commit/submodule_status_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostCommit::SubmoduleStatus do

--- a/spec/overcommit/hook/post_commit/yarn_install_spec.rb
+++ b/spec/overcommit/hook/post_commit/yarn_install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostCommit::YarnInstall do

--- a/spec/overcommit/hook/post_merge/bower_install_spec.rb
+++ b/spec/overcommit/hook/post_merge/bower_install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostMerge::BowerInstall do

--- a/spec/overcommit/hook/post_merge/bundle_install_spec.rb
+++ b/spec/overcommit/hook/post_merge/bundle_install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostMerge::BundleInstall do

--- a/spec/overcommit/hook/post_merge/composer_install_spec.rb
+++ b/spec/overcommit/hook/post_merge/composer_install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostMerge::ComposerInstall do

--- a/spec/overcommit/hook/post_merge/index_tags_spec.rb
+++ b/spec/overcommit/hook/post_merge/index_tags_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostMerge::IndexTags do

--- a/spec/overcommit/hook/post_merge/npm_install_spec.rb
+++ b/spec/overcommit/hook/post_merge/npm_install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostMerge::NpmInstall do

--- a/spec/overcommit/hook/post_merge/submodule_status_spec.rb
+++ b/spec/overcommit/hook/post_merge/submodule_status_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostMerge::SubmoduleStatus do

--- a/spec/overcommit/hook/post_merge/yarn_install_spec.rb
+++ b/spec/overcommit/hook/post_merge/yarn_install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostMerge::YarnInstall do

--- a/spec/overcommit/hook/post_rewrite/bower_install_spec.rb
+++ b/spec/overcommit/hook/post_rewrite/bower_install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostRewrite::BowerInstall do

--- a/spec/overcommit/hook/post_rewrite/bundle_install_spec.rb
+++ b/spec/overcommit/hook/post_rewrite/bundle_install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostRewrite::BundleInstall do

--- a/spec/overcommit/hook/post_rewrite/composer_install_spec.rb
+++ b/spec/overcommit/hook/post_rewrite/composer_install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostRewrite::ComposerInstall do

--- a/spec/overcommit/hook/post_rewrite/index_tags_spec.rb
+++ b/spec/overcommit/hook/post_rewrite/index_tags_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostMerge::IndexTags do

--- a/spec/overcommit/hook/post_rewrite/npm_install_spec.rb
+++ b/spec/overcommit/hook/post_rewrite/npm_install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostRewrite::NpmInstall do

--- a/spec/overcommit/hook/post_rewrite/submodule_status_spec.rb
+++ b/spec/overcommit/hook/post_rewrite/submodule_status_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostRewrite::SubmoduleStatus do

--- a/spec/overcommit/hook/post_rewrite/yarn_install_spec.rb
+++ b/spec/overcommit/hook/post_rewrite/yarn_install_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PostRewrite::YarnInstall do

--- a/spec/overcommit/hook/pre_commit/author_email_spec.rb
+++ b/spec/overcommit/hook/pre_commit/author_email_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::AuthorEmail do

--- a/spec/overcommit/hook/pre_commit/author_name_spec.rb
+++ b/spec/overcommit/hook/pre_commit/author_name_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::AuthorName do

--- a/spec/overcommit/hook/pre_commit/berksfile_check_spec.rb
+++ b/spec/overcommit/hook/pre_commit/berksfile_check_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::BerksfileCheck do

--- a/spec/overcommit/hook/pre_commit/broken_symlinks_spec.rb
+++ b/spec/overcommit/hook/pre_commit/broken_symlinks_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::BrokenSymlinks do

--- a/spec/overcommit/hook/pre_commit/bundle_audit_spec.rb
+++ b/spec/overcommit/hook/pre_commit/bundle_audit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::BundleAudit do

--- a/spec/overcommit/hook/pre_commit/bundle_check_spec.rb
+++ b/spec/overcommit/hook/pre_commit/bundle_check_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::BundleCheck do

--- a/spec/overcommit/hook/pre_commit/bundle_outdated_spec.rb
+++ b/spec/overcommit/hook/pre_commit/bundle_outdated_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::BundleOutdated do

--- a/spec/overcommit/hook/pre_commit/case_conflicts_spec.rb
+++ b/spec/overcommit/hook/pre_commit/case_conflicts_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::CaseConflicts do

--- a/spec/overcommit/hook/pre_commit/chamber_compare_spec.rb
+++ b/spec/overcommit/hook/pre_commit/chamber_compare_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::ChamberCompare do

--- a/spec/overcommit/hook/pre_commit/chamber_security_spec.rb
+++ b/spec/overcommit/hook/pre_commit/chamber_security_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::ChamberSecurity do

--- a/spec/overcommit/hook/pre_commit/chamber_verification_spec.rb
+++ b/spec/overcommit/hook/pre_commit/chamber_verification_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::ChamberVerification do

--- a/spec/overcommit/hook/pre_commit/coffee_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/coffee_lint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::CoffeeLint do

--- a/spec/overcommit/hook/pre_commit/credo_spec.rb
+++ b/spec/overcommit/hook/pre_commit/credo_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Credo do

--- a/spec/overcommit/hook/pre_commit/css_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/css_lint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::CssLint do

--- a/spec/overcommit/hook/pre_commit/dogma_spec.rb
+++ b/spec/overcommit/hook/pre_commit/dogma_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Dogma do

--- a/spec/overcommit/hook/pre_commit/es_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/es_lint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::EsLint do

--- a/spec/overcommit/hook/pre_commit/execute_permissions_spec.rb
+++ b/spec/overcommit/hook/pre_commit/execute_permissions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::ExecutePermissions do

--- a/spec/overcommit/hook/pre_commit/fasterer_spec.rb
+++ b/spec/overcommit/hook/pre_commit/fasterer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Fasterer do

--- a/spec/overcommit/hook/pre_commit/fix_me_spec.rb
+++ b/spec/overcommit/hook/pre_commit/fix_me_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::FixMe do

--- a/spec/overcommit/hook/pre_commit/flay_spec.rb
+++ b/spec/overcommit/hook/pre_commit/flay_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Flay do

--- a/spec/overcommit/hook/pre_commit/foodcritic_spec.rb
+++ b/spec/overcommit/hook/pre_commit/foodcritic_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Foodcritic do

--- a/spec/overcommit/hook/pre_commit/forbidden_branches_spec.rb
+++ b/spec/overcommit/hook/pre_commit/forbidden_branches_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::ForbiddenBranches do

--- a/spec/overcommit/hook/pre_commit/go_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/go_lint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::GoLint do

--- a/spec/overcommit/hook/pre_commit/go_vet_spec.rb
+++ b/spec/overcommit/hook/pre_commit/go_vet_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::GoVet do

--- a/spec/overcommit/hook/pre_commit/hadolint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/hadolint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Hadolint do

--- a/spec/overcommit/hook/pre_commit/haml_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/haml_lint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::HamlLint do

--- a/spec/overcommit/hook/pre_commit/hard_tabs_spec.rb
+++ b/spec/overcommit/hook/pre_commit/hard_tabs_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::HardTabs do

--- a/spec/overcommit/hook/pre_commit/hlint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/hlint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Hlint do

--- a/spec/overcommit/hook/pre_commit/html_hint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/html_hint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::HtmlHint do

--- a/spec/overcommit/hook/pre_commit/html_tidy_spec.rb
+++ b/spec/overcommit/hook/pre_commit/html_tidy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::HtmlTidy do

--- a/spec/overcommit/hook/pre_commit/image_optim_spec.rb
+++ b/spec/overcommit/hook/pre_commit/image_optim_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::ImageOptim do

--- a/spec/overcommit/hook/pre_commit/java_checkstyle_spec.rb
+++ b/spec/overcommit/hook/pre_commit/java_checkstyle_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::JavaCheckstyle do

--- a/spec/overcommit/hook/pre_commit/js_hint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/js_hint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::JsHint do

--- a/spec/overcommit/hook/pre_commit/js_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/js_lint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::JsLint do

--- a/spec/overcommit/hook/pre_commit/jscs_spec.rb
+++ b/spec/overcommit/hook/pre_commit/jscs_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Jscs do

--- a/spec/overcommit/hook/pre_commit/jsl_spec.rb
+++ b/spec/overcommit/hook/pre_commit/jsl_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Jsl do

--- a/spec/overcommit/hook/pre_commit/json_syntax_spec.rb
+++ b/spec/overcommit/hook/pre_commit/json_syntax_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'json'
 

--- a/spec/overcommit/hook/pre_commit/kt_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/kt_lint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::KtLint do

--- a/spec/overcommit/hook/pre_commit/license_finder_spec.rb
+++ b/spec/overcommit/hook/pre_commit/license_finder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::LicenseFinder do

--- a/spec/overcommit/hook/pre_commit/license_header_spec.rb
+++ b/spec/overcommit/hook/pre_commit/license_header_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::LicenseHeader do

--- a/spec/overcommit/hook/pre_commit/line_endings_spec.rb
+++ b/spec/overcommit/hook/pre_commit/line_endings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::LineEndings do

--- a/spec/overcommit/hook/pre_commit/local_paths_in_gemfile_spec.rb
+++ b/spec/overcommit/hook/pre_commit/local_paths_in_gemfile_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::LocalPathsInGemfile do

--- a/spec/overcommit/hook/pre_commit/mdl_spec.rb
+++ b/spec/overcommit/hook/pre_commit/mdl_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Mdl do

--- a/spec/overcommit/hook/pre_commit/merge_conflicts_spec.rb
+++ b/spec/overcommit/hook/pre_commit/merge_conflicts_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::MergeConflicts do

--- a/spec/overcommit/hook/pre_commit/nginx_test_spec.rb
+++ b/spec/overcommit/hook/pre_commit/nginx_test_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::NginxTest do

--- a/spec/overcommit/hook/pre_commit/pep257_spec.rb
+++ b/spec/overcommit/hook/pre_commit/pep257_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Pep257 do

--- a/spec/overcommit/hook/pre_commit/pep8_spec.rb
+++ b/spec/overcommit/hook/pre_commit/pep8_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Pep8 do

--- a/spec/overcommit/hook/pre_commit/php_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/php_lint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::PhpLint do

--- a/spec/overcommit/hook/pre_commit/php_stan_spec.rb
+++ b/spec/overcommit/hook/pre_commit/php_stan_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::PhpStan do

--- a/spec/overcommit/hook/pre_commit/phpcs_fixer_spec.rb
+++ b/spec/overcommit/hook/pre_commit/phpcs_fixer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::PhpCsFixer do

--- a/spec/overcommit/hook/pre_commit/phpcs_spec.rb
+++ b/spec/overcommit/hook/pre_commit/phpcs_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::PhpCs do

--- a/spec/overcommit/hook/pre_commit/pronto_spec.rb
+++ b/spec/overcommit/hook/pre_commit/pronto_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Pronto do

--- a/spec/overcommit/hook/pre_commit/puppet_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/puppet_lint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::PuppetLint do

--- a/spec/overcommit/hook/pre_commit/puppet_metadata_json_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/puppet_metadata_json_lint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::PuppetMetadataJsonLint do

--- a/spec/overcommit/hook/pre_commit/pycodestyle_spec.rb
+++ b/spec/overcommit/hook/pre_commit/pycodestyle_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Pycodestyle do

--- a/spec/overcommit/hook/pre_commit/pydocstyle_spec.rb
+++ b/spec/overcommit/hook/pre_commit/pydocstyle_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Pydocstyle do

--- a/spec/overcommit/hook/pre_commit/pyflakes_spec.rb
+++ b/spec/overcommit/hook/pre_commit/pyflakes_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Pyflakes do

--- a/spec/overcommit/hook/pre_commit/pylint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/pylint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Pylint do

--- a/spec/overcommit/hook/pre_commit/python_flake8_spec.rb
+++ b/spec/overcommit/hook/pre_commit/python_flake8_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::PythonFlake8 do

--- a/spec/overcommit/hook/pre_commit/rails_best_practices_spec.rb
+++ b/spec/overcommit/hook/pre_commit/rails_best_practices_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::RailsBestPractices do

--- a/spec/overcommit/hook/pre_commit/rails_schema_up_to_date_spec.rb
+++ b/spec/overcommit/hook/pre_commit/rails_schema_up_to_date_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::RailsSchemaUpToDate do

--- a/spec/overcommit/hook/pre_commit/rake_target_spec.rb
+++ b/spec/overcommit/hook/pre_commit/rake_target_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::RakeTarget do

--- a/spec/overcommit/hook/pre_commit/reek_spec.rb
+++ b/spec/overcommit/hook/pre_commit/reek_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Reek do

--- a/spec/overcommit/hook/pre_commit/rst_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/rst_lint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::RstLint do

--- a/spec/overcommit/hook/pre_commit/rubo_cop_spec.rb
+++ b/spec/overcommit/hook/pre_commit/rubo_cop_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::RuboCop do

--- a/spec/overcommit/hook/pre_commit/ruby_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/ruby_lint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::RubyLint do

--- a/spec/overcommit/hook/pre_commit/scalariform_spec.rb
+++ b/spec/overcommit/hook/pre_commit/scalariform_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Scalariform do

--- a/spec/overcommit/hook/pre_commit/scalastyle_spec.rb
+++ b/spec/overcommit/hook/pre_commit/scalastyle_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Scalastyle do

--- a/spec/overcommit/hook/pre_commit/scss_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/scss_lint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::ScssLint do

--- a/spec/overcommit/hook/pre_commit/semi_standard_spec.rb
+++ b/spec/overcommit/hook/pre_commit/semi_standard_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::SemiStandard do

--- a/spec/overcommit/hook/pre_commit/shell_check_spec.rb
+++ b/spec/overcommit/hook/pre_commit/shell_check_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::ShellCheck do

--- a/spec/overcommit/hook/pre_commit/slim_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/slim_lint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::SlimLint do

--- a/spec/overcommit/hook/pre_commit/sqlint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/sqlint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Sqlint do

--- a/spec/overcommit/hook/pre_commit/standard_spec.rb
+++ b/spec/overcommit/hook/pre_commit/standard_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Standard do

--- a/spec/overcommit/hook/pre_commit/stylelint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/stylelint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Stylelint do

--- a/spec/overcommit/hook/pre_commit/swift_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/swift_lint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::SwiftLint do

--- a/spec/overcommit/hook/pre_commit/trailing_whitespace_spec.rb
+++ b/spec/overcommit/hook/pre_commit/trailing_whitespace_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::TrailingWhitespace do

--- a/spec/overcommit/hook/pre_commit/travis_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/travis_lint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::TravisLint do

--- a/spec/overcommit/hook/pre_commit/ts_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/ts_lint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::TsLint do

--- a/spec/overcommit/hook/pre_commit/vint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/vint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::Vint do

--- a/spec/overcommit/hook/pre_commit/w3c_css_spec.rb
+++ b/spec/overcommit/hook/pre_commit/w3c_css_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::W3cCss do

--- a/spec/overcommit/hook/pre_commit/w3c_html_spec.rb
+++ b/spec/overcommit/hook/pre_commit/w3c_html_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::W3cHtml do

--- a/spec/overcommit/hook/pre_commit/xml_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/xml_lint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::XmlLint do

--- a/spec/overcommit/hook/pre_commit/xml_syntax_spec.rb
+++ b/spec/overcommit/hook/pre_commit/xml_syntax_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'rexml/document'
 

--- a/spec/overcommit/hook/pre_commit/yaml_lint_spec.rb
+++ b/spec/overcommit/hook/pre_commit/yaml_lint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::YamlLint do

--- a/spec/overcommit/hook/pre_commit/yaml_syntax_spec.rb
+++ b/spec/overcommit/hook/pre_commit/yaml_syntax_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::YamlSyntax do

--- a/spec/overcommit/hook/pre_commit/yard_coverage_spec.rb
+++ b/spec/overcommit/hook/pre_commit/yard_coverage_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::YardCoverage do

--- a/spec/overcommit/hook/pre_commit/yarn_check_spec.rb
+++ b/spec/overcommit/hook/pre_commit/yarn_check_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreCommit::YarnCheck do

--- a/spec/overcommit/hook/pre_push/brakeman_spec.rb
+++ b/spec/overcommit/hook/pre_push/brakeman_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PrePush::Brakeman do

--- a/spec/overcommit/hook/pre_push/cargo_test_spec.rb
+++ b/spec/overcommit/hook/pre_push/cargo_test_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PrePush::CargoTest do

--- a/spec/overcommit/hook/pre_push/minitest_spec.rb
+++ b/spec/overcommit/hook/pre_push/minitest_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PrePush::Minitest do

--- a/spec/overcommit/hook/pre_push/php_unit_spec.rb
+++ b/spec/overcommit/hook/pre_push/php_unit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PrePush::PhpUnit do

--- a/spec/overcommit/hook/pre_push/protected_branches_spec.rb
+++ b/spec/overcommit/hook/pre_push/protected_branches_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'overcommit/hook_context/pre_push'
 

--- a/spec/overcommit/hook/pre_push/pytest_spec.rb
+++ b/spec/overcommit/hook/pre_push/pytest_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PrePush::Pytest do

--- a/spec/overcommit/hook/pre_push/python_nose_spec.rb
+++ b/spec/overcommit/hook/pre_push/python_nose_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PrePush::PythonNose do

--- a/spec/overcommit/hook/pre_push/r_spec_spec.rb
+++ b/spec/overcommit/hook/pre_push/r_spec_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PrePush::RSpec do

--- a/spec/overcommit/hook/pre_push/rake_target_spec.rb
+++ b/spec/overcommit/hook/pre_push/rake_target_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PrePush::RakeTarget do

--- a/spec/overcommit/hook/pre_push/test_unit_spec.rb
+++ b/spec/overcommit/hook/pre_push/test_unit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PrePush::TestUnit do

--- a/spec/overcommit/hook/pre_rebase/merged_commits_spec.rb
+++ b/spec/overcommit/hook/pre_rebase/merged_commits_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Hook::PreRebase::MergedCommits do

--- a/spec/overcommit/hook/prepare_commit_msg/base_spec.rb
+++ b/spec/overcommit/hook/prepare_commit_msg/base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'overcommit/hook_context/prepare_commit_msg'
 

--- a/spec/overcommit/hook/prepare_commit_msg/replace_branch_spec.rb
+++ b/spec/overcommit/hook/prepare_commit_msg/replace_branch_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'overcommit/hook_context/prepare_commit_msg'
 

--- a/spec/overcommit/hook_context/base_spec.rb
+++ b/spec/overcommit/hook_context/base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::HookContext::Base do

--- a/spec/overcommit/hook_context/commit_msg_spec.rb
+++ b/spec/overcommit/hook_context/commit_msg_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'overcommit/hook_context/commit_msg'
 

--- a/spec/overcommit/hook_context/post_checkout_spec.rb
+++ b/spec/overcommit/hook_context/post_checkout_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'overcommit/hook_context/post_checkout'
 

--- a/spec/overcommit/hook_context/post_commit_spec.rb
+++ b/spec/overcommit/hook_context/post_commit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'overcommit/hook_context/post_commit'
 

--- a/spec/overcommit/hook_context/post_merge_spec.rb
+++ b/spec/overcommit/hook_context/post_merge_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'overcommit/hook_context/post_merge'
 

--- a/spec/overcommit/hook_context/post_rewrite_spec.rb
+++ b/spec/overcommit/hook_context/post_rewrite_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'overcommit/hook_context/post_rewrite'
 

--- a/spec/overcommit/hook_context/pre_commit_spec.rb
+++ b/spec/overcommit/hook_context/pre_commit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'overcommit/hook_context/pre_commit'
 

--- a/spec/overcommit/hook_context/pre_push_spec.rb
+++ b/spec/overcommit/hook_context/pre_push_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'overcommit/hook_context/pre_push'
 

--- a/spec/overcommit/hook_context/pre_rebase_spec.rb
+++ b/spec/overcommit/hook_context/pre_rebase_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'overcommit/hook_context/pre_rebase'
 

--- a/spec/overcommit/hook_context/prepare_commit_msg_spec.rb
+++ b/spec/overcommit/hook_context/prepare_commit_msg_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'overcommit/hook_context/prepare_commit_msg'
 

--- a/spec/overcommit/hook_context/run_all_spec.rb
+++ b/spec/overcommit/hook_context/run_all_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'overcommit/hook_context/run_all'
 

--- a/spec/overcommit/hook_signer_spec.rb
+++ b/spec/overcommit/hook_signer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::HookSigner do

--- a/spec/overcommit/installer_spec.rb
+++ b/spec/overcommit/installer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Installer do

--- a/spec/overcommit/logger_spec.rb
+++ b/spec/overcommit/logger_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::Logger do

--- a/spec/overcommit/message_processor_spec.rb
+++ b/spec/overcommit/message_processor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Overcommit::MessageProcessor do

--- a/spec/overcommit/utils_spec.rb
+++ b/spec/overcommit/utils_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'securerandom'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if ENV['TRAVIS']
   # When running in Travis, report coverage stats to Coveralls.
   require 'coveralls'

--- a/spec/support/git_spec_helpers.rb
+++ b/spec/support/git_spec_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tmpdir'
 
 # Helpers for creating temporary repositories and directories for testing.

--- a/spec/support/matchers/hook.rb
+++ b/spec/support/matchers/hook.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # General spec matcher logic for checking hook status and output.
 class HookMatcher
   def initialize(status, args)

--- a/spec/support/normalize_indent.rb
+++ b/spec/support/normalize_indent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Strips off excess leading indentation from each line so we can use Heredocs
 # for writing code without having the leading indentation count.
 module IndentNormalizer

--- a/spec/support/output_helpers.rb
+++ b/spec/support/output_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Helpers for capturing output streams in tests.
 module OutputHelpers
   module_function

--- a/spec/support/shell_helpers.rb
+++ b/spec/support/shell_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'timeout'
 require 'overcommit/subprocess'
 

--- a/template-dir/hooks/commit-msg
+++ b/template-dir/hooks/commit-msg
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework

--- a/template-dir/hooks/overcommit-hook
+++ b/template-dir/hooks/overcommit-hook
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework

--- a/template-dir/hooks/post-checkout
+++ b/template-dir/hooks/post-checkout
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework

--- a/template-dir/hooks/post-commit
+++ b/template-dir/hooks/post-commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework

--- a/template-dir/hooks/post-merge
+++ b/template-dir/hooks/post-merge
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework

--- a/template-dir/hooks/post-rewrite
+++ b/template-dir/hooks/post-rewrite
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework

--- a/template-dir/hooks/pre-commit
+++ b/template-dir/hooks/pre-commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework

--- a/template-dir/hooks/pre-push
+++ b/template-dir/hooks/pre-push
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework

--- a/template-dir/hooks/pre-rebase
+++ b/template-dir/hooks/pre-rebase
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework

--- a/template-dir/hooks/prepare-commit-msg
+++ b/template-dir/hooks/prepare-commit-msg
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # Entrypoint for Overcommit hook integration. Installing Overcommit will result
 # in all of your git hooks being copied from this file, allowing the framework


### PR DESCRIPTION
- Add the magic comment to all files
- Update Overcommit::HookContext::PreCommit to not use encode!
- Set Rubocop target Ruby version to 2.3