### PR TITLE
CI: Include Ruby 2.6.0 in build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - 2.3.7
   - 2.4.4
   - 2.5.1
+  - 2.6
 
 before_script:
   - git config --global user.email "travis@travis.ci"
@@ -16,7 +17,7 @@ before_script:
 
 before_install:
   - gem update --system
-  - gem install bundler
+  - gem install bundler:'< 2'
 
 script:
   - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ before_script:
 
 before_install:
   - |
-    export RVM_CURRENT=`rvm current`
-    if [ "${RVM_CURRENT}" == "ruby-2.2.7" ]; then
+    export RVM_CURRENT=`rvm current|cut -c6-8`
+    if [ "${RVM_CURRENT}" == "2.2" ]; then
       gem --version
     else
       gem update --system

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
 before_install:
   - |
     export RVM_CURRENT=`rvm current`
-    if [ "${RVM_CURRENT}" != "ruby-2.2.7" ]; then
+    if [ "${RVM_CURRENT}" == "ruby-2.2.7" ]; then
       gem --version
     else
       gem update --system

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,13 @@ before_script:
   - git config --global user.name "Travis CI"
 
 before_install:
-  - gem update --system
+  - |
+    export RVM_CURRENT=`rvm current`
+    if [ "${RVM_CURRENT}" != "ruby-2.2.7" ]; then
+      gem --version
+    else
+      gem update --system
+    fi
   - gem install bundler:'< 2'
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,12 @@ environment:
     - RUBY_FOLDER_VERSION: "22-x64"
     - RUBY_FOLDER_VERSION: "23"
     - RUBY_FOLDER_VERSION: "23-x64"
-
+    - RUBY_FOLDER_VERSION: "24"
+    - RUBY_FOLDER_VERSION: "24-x64"
+    - RUBY_FOLDER_VERSION: "25"
+    - RUBY_FOLDER_VERSION: "25-x64"
+    - RUBY_FOLDER_VERSION: "26"
+    - RUBY_FOLDER_VERSION: "26-x64"
 matrix:
   fast_finish: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ install:
   - where gem
 
   # Install latest Bundler to work around version issues
-  - gem install bundler --force
+  - gem install bundler:'< 2' --force
   - where bundler
 
   # Install ruby dependencies


### PR DESCRIPTION
This PR extends the matrix.

It also tries to keep the Bundler version before 2.0.