### PR TITLE
Add --force-exclusion flag to default Reek config

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -619,7 +619,7 @@ PreCommit:
     enabled: false
     description: 'Analyze with Reek'
     required_executable: 'reek'
-    flags: ['--single-line', '--no-color']
+    flags: ['--single-line', '--no-color', '--force-exclusion']
     install_command: 'gem install reek'
     include:
       - '**/*.gemspec'


### PR DESCRIPTION
Similar to the flag provided by Rubocop, the `--force-exclusion` flag ensures files excluded via the `exclude_paths` config option are still excluded when they are explicitly passed to the `reek` command.