### PR TITLE
AppVeyor: Workaround 2.3 rubygems update [incomplete]

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ install:
   - where ruby
 
   # Install latest version of RubyGems
-  - gem update --system --no-ri --no-rdoc
+  - gem update --system --no-rdoc
   - gem --version
   - where gem
 


### PR DESCRIPTION
This PR tries to fix the build on Windows.

  - in the "gem" shipped with 2.3, the --no-ri was not present

```
gem update --system --no-ri --no-rdoc
ERROR:  While executing gem ... (OptionParser::InvalidOption)
    invalid option: --no-ri
```