### PR TITLE
CI: Drop unused Travis option "sudo: false"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 
-sudo: false
-
 cache: bundler
 
 rvm:


### PR DESCRIPTION
This PR simplifies the CI configuration by dropping a now-unused option.