### PR TITLE
Drop support for Ruby 2.2

### DIFF
--- a/.git-hooks/pre_commit/master_hooks_match.rb
+++ b/.git-hooks/pre_commit/master_hooks_match.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 
 module Overcommit::Hook::PreCommit

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
 
 Layout/ClosingParenthesisIndentation:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,25 +3,18 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.2
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
-  - 2.6
+  - 2.3.8
+  - 2.4.5
+  - 2.5.5
+  - 2.6.2
 
 before_script:
   - git config --global user.email "travis@travis.ci"
   - git config --global user.name "Travis CI"
 
 before_install:
-  - |
-    export RVM_CURRENT=`rvm current|cut -c6-8`
-    if [ "${RVM_CURRENT}" == "2.2" ]; then
-      gem --version
-    else
-      gem update --system
-    fi
-  - gem install bundler:'< 2'
+  - gem update --system
+  - gem install bundler
 
 script:
   - bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Overcommit Changelog
 
+## master (unreleased)
+
+* Drop support for Ruby 2.2
+
 ## 0.47.0
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ any Ruby code.
 
 This project aims to support the following Ruby runtimes on both \*nix and Windows:
 
-* MRI 2.2+
+* MRI 2.3+
 
 ### Dependencies
 

--- a/lib/overcommit/constants.rb
+++ b/lib/overcommit/constants.rb
@@ -3,10 +3,10 @@
 # Global application constants.
 module Overcommit
   HOME = File.expand_path(File.join(File.dirname(__FILE__), '..', '..')).freeze
-  CONFIG_FILE_NAME = '.overcommit.yml'.freeze
+  CONFIG_FILE_NAME = '.overcommit.yml'
 
   HOOK_DIRECTORY = File.join(HOME, 'lib', 'overcommit', 'hook').freeze
 
-  REPO_URL = 'https://github.com/brigade/overcommit'.freeze
-  BUG_REPORT_URL = "#{REPO_URL}/issues".freeze
+  REPO_URL = 'https://github.com/brigade/overcommit'
+  BUG_REPORT_URL = "#{REPO_URL}/issues"
 end

--- a/lib/overcommit/hook/pre_commit/berksfile_check.rb
+++ b/lib/overcommit/hook/pre_commit/berksfile_check.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PreCommit
   #
   # @see http://berkshelf.com/
   class BerksfileCheck < Base
-    LOCK_FILE = 'Berksfile.lock'.freeze
+    LOCK_FILE = 'Berksfile.lock'
 
     def run
       # Ignore if Berksfile.lock is not tracked by git

--- a/lib/overcommit/hook/pre_commit/bundle_audit.rb
+++ b/lib/overcommit/hook/pre_commit/bundle_audit.rb
@@ -5,7 +5,7 @@ module Overcommit::Hook::PreCommit
   #
   # @see https://github.com/rubysec/bundler-audit
   class BundleAudit < Base
-    LOCK_FILE = 'Gemfile.lock'.freeze
+    LOCK_FILE = 'Gemfile.lock'
 
     def run
       # Ignore if Gemfile.lock is not tracked by git

--- a/lib/overcommit/hook/pre_commit/bundle_check.rb
+++ b/lib/overcommit/hook/pre_commit/bundle_check.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PreCommit
   #
   # @see http://bundler.io/
   class BundleCheck < Base
-    LOCK_FILE = 'Gemfile.lock'.freeze
+    LOCK_FILE = 'Gemfile.lock'
 
     def run
       # Ignore if Gemfile.lock is not tracked by git

--- a/lib/overcommit/hook/pre_commit/bundle_outdated.rb
+++ b/lib/overcommit/hook/pre_commit/bundle_outdated.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PreCommit
   #
   # @see http://bundler.io/bundle_outdated.html
   class BundleOutdated < Base
-    LOCK_FILE = 'Gemfile.lock'.freeze
+    LOCK_FILE = 'Gemfile.lock'
 
     def run
       # Ignore if Gemfile.lock is not tracked by git

--- a/lib/overcommit/hook/pre_commit/yarn_check.rb
+++ b/lib/overcommit/hook/pre_commit/yarn_check.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PreCommit
   #
   # @see https://yarnpkg.com/en/docs/cli/check
   class YarnCheck < Base
-    LOCK_FILE = 'yarn.lock'.freeze
+    LOCK_FILE = 'yarn.lock'
 
     # A lot of the errors returned by `yarn check` are outside the developer's control
     # (are caused by bad package specification, in the hands of the upstream maintainer)

--- a/lib/overcommit/hook_context/prepare_commit_msg.rb
+++ b/lib/overcommit/hook_context/prepare_commit_msg.rb
@@ -16,7 +16,7 @@ module Overcommit::HookContext
     # exists); or commit, followed by a commit SHA-1 (if a -c, -C or --amend
     # option was given)
     def commit_message_source
-      @args[1].to_sym if @args[1]
+      @args[1]&.to_sym
     end
 
     # Returns the commit's SHA-1.

--- a/lib/overcommit/message_processor.rb
+++ b/lib/overcommit/message_processor.rb
@@ -8,12 +8,12 @@ module Overcommit
   # output tuple from an array of {Overcommit::Hook::Message}s, respecting the
   # configuration settings for the given hook.
   class MessageProcessor
-    ERRORS_MODIFIED_HEADER = 'Errors on modified lines:'.freeze
-    WARNINGS_MODIFIED_HEADER = 'Warnings on modified lines:'.freeze
-    ERRORS_UNMODIFIED_HEADER = "Errors on lines you didn't modify:".freeze
-    WARNINGS_UNMODIFIED_HEADER = "Warnings on lines you didn't modify:".freeze
-    ERRORS_GENERIC_HEADER = 'Errors:'.freeze
-    WARNINGS_GENERIC_HEADER = 'Warnings:'.freeze
+    ERRORS_MODIFIED_HEADER = 'Errors on modified lines:'
+    WARNINGS_MODIFIED_HEADER = 'Warnings on modified lines:'
+    ERRORS_UNMODIFIED_HEADER = "Errors on lines you didn't modify:"
+    WARNINGS_UNMODIFIED_HEADER = "Warnings on lines you didn't modify:"
+    ERRORS_GENERIC_HEADER = 'Errors:'
+    WARNINGS_GENERIC_HEADER = 'Warnings:'
 
     # @param hook [Overcommit::Hook::Base]
     # @param unmodified_lines_setting [String] how to treat messages on

--- a/lib/overcommit/utils.rb
+++ b/lib/overcommit/utils.rb
@@ -297,7 +297,7 @@ module Overcommit
       #
       # @param args [Array<String>]
       def debug(*args)
-        log.debug(*args) if log
+        log&.debug(*args)
       end
     end
   end

--- a/lib/overcommit/version.rb
+++ b/lib/overcommit/version.rb
@@ -2,5 +2,5 @@
 
 # Defines the gem version.
 module Overcommit
-  VERSION = '0.47.0'.freeze
+  VERSION = '0.47.0'
 end

--- a/overcommit.gemspec
+++ b/overcommit.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
                             Dir['libexec/**/*'] +
                             Dir['template-dir/**/*']
 
-  s.required_ruby_version = '>= 2.2'
+  s.required_ruby_version = '>= 2.3'
 
   s.add_dependency          'childprocess', '~> 0.6', '>= 0.6.3'
   s.add_dependency          'iniparse', '~> 1.4'


### PR DESCRIPTION
Ruby 2.2 has been EOL since June 2018. Supporting it requires additional effort in our test environment, so drop support.