### PR TITLE
CommitMsg MessageFormat: multiline match

### DIFF
--- a/lib/overcommit/hook/commit_msg/message_format.rb
+++ b/lib/overcommit/hook/commit_msg/message_format.rb
@@ -19,7 +19,7 @@ module Overcommit::Hook::CommitMsg
       expected_pattern_message = config['expected_pattern_message']
       sample_message = config['sample_message']
 
-      unless message =~ /#{pattern}/
+      unless message =~ /#{pattern}/m
         [
           'Commit message pattern mismatch.',
           "Expected : #{expected_pattern_message}",

--- a/spec/overcommit/hook/commit_msg/message_format_spec.rb
+++ b/spec/overcommit/hook/commit_msg/message_format_spec.rb
@@ -39,4 +39,20 @@ describe Overcommit::Hook::CommitMsg::MessageFormat do
 
     it { should fail_hook expected_message }
   end
+
+  context 'when multiline message matches the pattern' do
+    let(:config) do
+      super().merge(Overcommit::Configuration.new(
+        'CommitMsg' => {
+          'MessageFormat' => {
+            'pattern' => '^Some .* Message$'
+          }
+        }
+      ))
+    end
+
+    let(:commit_msg) { "Some \n multiline \n Message" }
+
+    it { should pass }
+  end
 end


### PR DESCRIPTION
Add m flag to regexp check to allow matching over multiple lines.