### PR TITLE
Avoid YARD warning "RedundantBraces

### DIFF
--- a/lib/overcommit/hook/post_checkout/bower_install.rb
+++ b/lib/overcommit/hook/post_checkout/bower_install.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PostCheckout
   # Runs `bower install` when a change is detected in the repository's
   # dependencies.
   #
-  # @see {Overcommit::Hook::Shared::BowerInstall}
+  # @see Overcommit::Hook::Shared::BowerInstall
   class BowerInstall < Base
     include Overcommit::Hook::Shared::BowerInstall
   end

--- a/lib/overcommit/hook/post_checkout/bundle_install.rb
+++ b/lib/overcommit/hook/post_checkout/bundle_install.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PostCheckout
   # Runs `bundle install` when a change is detected in the repository's
   # dependencies.
   #
-  # @see {Overcommit::Hook::Shared::BundleInstall}
+  # @see Overcommit::Hook::Shared::BundleInstall
   class BundleInstall < Base
     include Overcommit::Hook::Shared::BundleInstall
   end

--- a/lib/overcommit/hook/post_checkout/composer_install.rb
+++ b/lib/overcommit/hook/post_checkout/composer_install.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PostCheckout
   # Runs `composer install` when a change is detected in the repository's
   # dependencies.
   #
-  # @see {Overcommit::Hook::Shared::ComposerInstall}
+  # @see Overcommit::Hook::Shared::ComposerInstall
   class ComposerInstall < Base
     include Overcommit::Hook::Shared::ComposerInstall
   end

--- a/lib/overcommit/hook/post_checkout/index_tags.rb
+++ b/lib/overcommit/hook/post_checkout/index_tags.rb
@@ -5,7 +5,7 @@ require 'overcommit/hook/shared/index_tags'
 module Overcommit::Hook::PostCheckout
   # Updates ctags index for all source code in the repository.
   #
-  # @see {Overcommit::Hook::Shared::IndexTags}
+  # @see Overcommit::Hook::Shared::IndexTags
   class IndexTags < Base
     include Overcommit::Hook::Shared::IndexTags
   end

--- a/lib/overcommit/hook/post_checkout/npm_install.rb
+++ b/lib/overcommit/hook/post_checkout/npm_install.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PostCheckout
   # Runs `npm install` when a change is detected in the repository's
   # dependencies.
   #
-  # @see {Overcommit::Hook::Shared::NpmInstall}
+  # @see Overcommit::Hook::Shared::NpmInstall
   class NpmInstall < Base
     include Overcommit::Hook::Shared::NpmInstall
   end

--- a/lib/overcommit/hook/post_checkout/yarn_install.rb
+++ b/lib/overcommit/hook/post_checkout/yarn_install.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PostCheckout
   # Runs `yarn install` when a change is detected in the repository's
   # dependencies.
   #
-  # @see {Overcommit::Hook::Shared::YarnInstall}
+  # @see Overcommit::Hook::Shared::YarnInstall
   class YarnInstall < Base
     include Overcommit::Hook::Shared::YarnInstall
   end

--- a/lib/overcommit/hook/post_commit/bower_install.rb
+++ b/lib/overcommit/hook/post_commit/bower_install.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PostCommit
   # Runs `bower install` when a change is detected in the repository's
   # dependencies.
   #
-  # @see {Overcommit::Hook::Shared::BowerInstall}
+  # @see Overcommit::Hook::Shared::BowerInstall
   class BowerInstall < Base
     include Overcommit::Hook::Shared::BowerInstall
   end

--- a/lib/overcommit/hook/post_commit/bundle_install.rb
+++ b/lib/overcommit/hook/post_commit/bundle_install.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PostCommit
   # Runs `bundle install` when a change is detected in the repository's
   # dependencies.
   #
-  # @see {Overcommit::Hook::Shared::BundleInstall}
+  # @see Overcommit::Hook::Shared::BundleInstall
   class BundleInstall < Base
     include Overcommit::Hook::Shared::BundleInstall
   end

--- a/lib/overcommit/hook/post_commit/composer_install.rb
+++ b/lib/overcommit/hook/post_commit/composer_install.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PostCommit
   # Runs `composer install` when a change is detected in the repository's
   # dependencies.
   #
-  # @see {Overcommit::Hook::Shared::ComposerInstall}
+  # @see Overcommit::Hook::Shared::ComposerInstall
   class ComposerInstall < Base
     include Overcommit::Hook::Shared::ComposerInstall
   end

--- a/lib/overcommit/hook/post_commit/index_tags.rb
+++ b/lib/overcommit/hook/post_commit/index_tags.rb
@@ -5,7 +5,7 @@ require 'overcommit/hook/shared/index_tags'
 module Overcommit::Hook::PostCommit
   # Updates ctags index for all source code in the repository.
   #
-  # @see {Overcommit::Hook::Shared::IndexTags}
+  # @see Overcommit::Hook::Shared::IndexTags
   class IndexTags < Base
     include Overcommit::Hook::Shared::IndexTags
   end

--- a/lib/overcommit/hook/post_commit/npm_install.rb
+++ b/lib/overcommit/hook/post_commit/npm_install.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PostCommit
   # Runs `npm install` when a change is detected in the repository's
   # dependencies.
   #
-  # @see {Overcommit::Hook::Shared::NpmInstall}
+  # @see Overcommit::Hook::Shared::NpmInstall
   class NpmInstall < Base
     include Overcommit::Hook::Shared::NpmInstall
   end

--- a/lib/overcommit/hook/post_commit/yarn_install.rb
+++ b/lib/overcommit/hook/post_commit/yarn_install.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PostCommit
   # Runs `yarn install` when a change is detected in the repository's
   # dependencies.
   #
-  # @see {Overcommit::Hook::Shared::YarnInstall}
+  # @see Overcommit::Hook::Shared::YarnInstall
   class YarnInstall < Base
     include Overcommit::Hook::Shared::YarnInstall
   end

--- a/lib/overcommit/hook/post_merge/bower_install.rb
+++ b/lib/overcommit/hook/post_merge/bower_install.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PostMerge
   # Runs `bower install` when a change is detected in the repository's
   # dependencies.
   #
-  # @see {Overcommit::Hook::Shared::BowerInstall}
+  # @see Overcommit::Hook::Shared::BowerInstall
   class BowerInstall < Base
     include Overcommit::Hook::Shared::BowerInstall
   end

--- a/lib/overcommit/hook/post_merge/bundle_install.rb
+++ b/lib/overcommit/hook/post_merge/bundle_install.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PostMerge
   # Runs `bundle install` when a change is detected in the repository's
   # dependencies.
   #
-  # @see {Overcommit::Hook::Shared::BundleInstall}
+  # @see Overcommit::Hook::Shared::BundleInstall
   class BundleInstall < Base
     include Overcommit::Hook::Shared::BundleInstall
   end

--- a/lib/overcommit/hook/post_merge/composer_install.rb
+++ b/lib/overcommit/hook/post_merge/composer_install.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PostMerge
   # Runs `composer install` when a change is detected in the repository's
   # dependencies.
   #
-  # @see {Overcommit::Hook::Shared::ComposerInstall}
+  # @see Overcommit::Hook::Shared::ComposerInstall
   class ComposerInstall < Base
     include Overcommit::Hook::Shared::ComposerInstall
   end

--- a/lib/overcommit/hook/post_merge/index_tags.rb
+++ b/lib/overcommit/hook/post_merge/index_tags.rb
@@ -5,7 +5,7 @@ require 'overcommit/hook/shared/index_tags'
 module Overcommit::Hook::PostMerge
   # Updates ctags index for all source code in the repository.
   #
-  # @see {Overcommit::Hook::Shared::IndexTags}
+  # @see Overcommit::Hook::Shared::IndexTags
   class IndexTags < Base
     include Overcommit::Hook::Shared::IndexTags
   end

--- a/lib/overcommit/hook/post_merge/npm_install.rb
+++ b/lib/overcommit/hook/post_merge/npm_install.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PostMerge
   # Runs `npm install` when a change is detected in the repository's
   # dependencies.
   #
-  # @see {Overcommit::Hook::Shared::NpmInstall}
+  # @see Overcommit::Hook::Shared::NpmInstall
   class NpmInstall < Base
     include Overcommit::Hook::Shared::NpmInstall
   end

--- a/lib/overcommit/hook/post_merge/yarn_install.rb
+++ b/lib/overcommit/hook/post_merge/yarn_install.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PostMerge
   # Runs `yarn install` when a change is detected in the repository's
   # dependencies.
   #
-  # @see {Overcommit::Hook::Shared::YarnInstall}
+  # @see Overcommit::Hook::Shared::YarnInstall
   class YarnInstall < Base
     include Overcommit::Hook::Shared::YarnInstall
   end

--- a/lib/overcommit/hook/post_rewrite/bower_install.rb
+++ b/lib/overcommit/hook/post_rewrite/bower_install.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PostRewrite
   # Runs `bower install` when a change is detected in the repository's
   # dependencies.
   #
-  # @see {Overcommit::Hook::Shared::BowerInstall}
+  # @see Overcommit::Hook::Shared::BowerInstall
   class BowerInstall < Base
     include Overcommit::Hook::Shared::BowerInstall
   end

--- a/lib/overcommit/hook/post_rewrite/bundle_install.rb
+++ b/lib/overcommit/hook/post_rewrite/bundle_install.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PostRewrite
   # Runs `bundle install` when a change is detected in the repository's
   # dependencies.
   #
-  # @see {Overcommit::Hook::Shared::BundleInstall}
+  # @see Overcommit::Hook::Shared::BundleInstall
   class BundleInstall < Base
     include Overcommit::Hook::Shared::BundleInstall
   end

--- a/lib/overcommit/hook/post_rewrite/composer_install.rb
+++ b/lib/overcommit/hook/post_rewrite/composer_install.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PostRewrite
   # Runs `composer install` when a change is detected in the repository's
   # dependencies.
   #
-  # @see {Overcommit::Hook::Shared::ComposerInstall}
+  # @see Overcommit::Hook::Shared::ComposerInstall
   class ComposerInstall < Base
     include Overcommit::Hook::Shared::ComposerInstall
   end

--- a/lib/overcommit/hook/post_rewrite/index_tags.rb
+++ b/lib/overcommit/hook/post_rewrite/index_tags.rb
@@ -5,7 +5,7 @@ require 'overcommit/hook/shared/index_tags'
 module Overcommit::Hook::PostRewrite
   # Updates ctags index for all source code in the repository.
   #
-  # @see {Overcommit::Hook::Shared::IndexTags}
+  # @see Overcommit::Hook::Shared::IndexTags
   class IndexTags < Base
     include Overcommit::Hook::Shared::IndexTags
 

--- a/lib/overcommit/hook/post_rewrite/npm_install.rb
+++ b/lib/overcommit/hook/post_rewrite/npm_install.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PostRewrite
   # Runs `npm install` when a change is detected in the repository's
   # dependencies.
   #
-  # @see {Overcommit::Hook::Shared::NpmInstall}
+  # @see Overcommit::Hook::Shared::NpmInstall
   class NpmInstall < Base
     include Overcommit::Hook::Shared::NpmInstall
   end

--- a/lib/overcommit/hook/post_rewrite/yarn_install.rb
+++ b/lib/overcommit/hook/post_rewrite/yarn_install.rb
@@ -6,7 +6,7 @@ module Overcommit::Hook::PostRewrite
   # Runs `yarn install` when a change is detected in the repository's
   # dependencies.
   #
-  # @see {Overcommit::Hook::Shared::YarnInstall}
+  # @see Overcommit::Hook::Shared::YarnInstall
   class YarnInstall < Base
     include Overcommit::Hook::Shared::YarnInstall
   end

--- a/lib/overcommit/hook/pre_commit/rake_target.rb
+++ b/lib/overcommit/hook/pre_commit/rake_target.rb
@@ -5,7 +5,7 @@ require 'overcommit/hook/shared/rake_target'
 module Overcommit::Hook::PreCommit
   # Runs rake targets
   #
-  # @see {Overcommit::Hook::Shared::RakeTarget}
+  # @see Overcommit::Hook::Shared::RakeTarget
   class RakeTarget < Base
     include Overcommit::Hook::Shared::RakeTarget
   end

--- a/lib/overcommit/hook/pre_push/rake_target.rb
+++ b/lib/overcommit/hook/pre_push/rake_target.rb
@@ -5,7 +5,7 @@ require 'overcommit/hook/shared/rake_target'
 module Overcommit::Hook::PrePush
   # Runs rake targets
   #
-  # @see {Overcommit::Hook::Shared::RakeTarget}
+  # @see Overcommit::Hook::Shared::RakeTarget
   class RakeTarget < Base
     include Overcommit::Hook::Shared::RakeTarget
   end


### PR DESCRIPTION
This PR updates the YARD doc comment to avoid warnings:

<details>

```
lib/overcommit/hook/pre_push/rake_target.rb:8: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_merge/index_tags.rb:8: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_commit/index_tags.rb:8: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_merge/npm_install.rb:9: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/pre_commit/rake_target.rb:8: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_commit/npm_install.rb:9: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_merge/yarn_install.rb:9: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_rewrite/index_tags.rb:8: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_checkout/index_tags.rb:8: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_commit/yarn_install.rb:9: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_merge/bower_install.rb:9: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_rewrite/npm_install.rb:9: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_checkout/npm_install.rb:9: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_commit/bower_install.rb:9: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_merge/bundle_install.rb:9: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_rewrite/yarn_install.rb:9: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_checkout/yarn_install.rb:9: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_commit/bundle_install.rb:9: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_rewrite/bower_install.rb:9: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_checkout/bower_install.rb:9: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_merge/composer_install.rb:9: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_rewrite/bundle_install.rb:9: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_checkout/bundle_install.rb:9: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_commit/composer_install.rb:9: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_rewrite/composer_install.rb:9: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
lib/overcommit/hook/post_checkout/composer_install.rb:9: [RedundantBraces] @see tag should not be wrapped in {} (causes rendering issues)
```

</details>