### PR TITLE
Implement FileSize pre-commit hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * Drop support for Ruby 2.2
+* Add `FileSize` pre-commit hook
 
 ## 0.47.0
 

--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ issue](https://github.com/brigade/overcommit/issues/238) for more details.
 * [EsLint](lib/overcommit/hook/pre_commit/es_lint.rb)
 * [ExecutePermissions](lib/overcommit/hook/pre_commit/execute_permissions.rb)
 * [Fasterer](lib/overcommit/hook/pre_commit/fasterer.rb)
+* [FileSize](lib/overcommit/hook/pre_commit/file_size.rb)
 * [FixMe](lib/overcommit/hook/pre_commit/fix_me.rb)
 * [Flay](lib/overcommit/hook/pre_commit/flay.rb)
 * [Foodcritic](lib/overcommit/hook/pre_commit/foodcritic.rb)

--- a/config/default.yml
+++ b/config/default.yml
@@ -295,6 +295,7 @@ PreCommit:
 
   FileSize:
     enabled: false
+    description: 'Check for oversized files'
     size_limit_bytes: 1_000_000
 
   Flay:

--- a/config/default.yml
+++ b/config/default.yml
@@ -296,6 +296,7 @@ PreCommit:
   FileSize:
     enabled: false
     description: 'Check for oversized files'
+    size_limit_bytes: 1_000_000
 
   Flay:
     enabled: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -295,7 +295,6 @@ PreCommit:
 
   FileSize:
     enabled: false
-    description: 'Check for oversized files'
     size_limit_bytes: 1_000_000
 
   Flay:

--- a/config/default.yml
+++ b/config/default.yml
@@ -293,6 +293,10 @@ PreCommit:
     flags: ['-IEHnw']
     keywords: ['BROKEN', 'BUG', 'ERROR', 'FIXME', 'HACK', 'NOTE', 'OPTIMIZE', 'REVIEW', 'TODO', 'WTF', 'XXX']
 
+  FileSize:
+    enabled: false
+    description: 'Check for oversized files'
+
   Flay:
     enabled: false
     description: 'Analyze ruby code for structural similarities with Flay'

--- a/lib/overcommit/hook/pre_commit/file_size.rb
+++ b/lib/overcommit/hook/pre_commit/file_size.rb
@@ -3,8 +3,6 @@
 module Overcommit::Hook::PreCommit
   # Checks for oversized files before committing.
   class FileSize < Base
-    DEFAULT_SIZE_LIMIT_BYTES = 1_000_000 # 1MB
-
     def run
       return :pass if oversized_files.empty?
 
@@ -26,7 +24,7 @@ module Overcommit::Hook::PreCommit
     end
 
     def size_limit_bytes
-      config.fetch('size_limit_bytes', DEFAULT_SIZE_LIMIT_BYTES)
+      config.fetch('size_limit_bytes')
     end
 
     def error_message_for(file)

--- a/lib/overcommit/hook/pre_commit/file_size.rb
+++ b/lib/overcommit/hook/pre_commit/file_size.rb
@@ -36,32 +36,12 @@ module Overcommit::Hook::PreCommit
         :error,
         file,
         nil,
-        error_text_for(file)
+        "#{file} is #{file_size(file)} bytes"
       )
-    end
-
-    def error_text_for(file)
-      error_text_format % {
-        path: relative_path_for(file),
-        limit: size_limit_bytes,
-        size: file_size(file)
-      }
-    end
-
-    def error_text_format
-      '%<path>s is over the file size limit of %<limit>s bytes (is %<size>s bytes)'
     end
 
     def file_size(file)
       File.size(file)
-    end
-
-    def relative_path_for(file)
-      Pathname.new(file).relative_path_from(repo_root_path)
-    end
-
-    def repo_root_path
-      @repo_root_path ||= Pathname.new(Overcommit::Utils.repo_root)
     end
   end
 end

--- a/lib/overcommit/hook/pre_commit/file_size.rb
+++ b/lib/overcommit/hook/pre_commit/file_size.rb
@@ -18,7 +18,7 @@ module Overcommit::Hook::PreCommit
 
       def build_oversized_file_list
         applicable_files.select do |file|
-          File.size(file) > size_limit_bytes
+          file_size(file) > size_limit_bytes
         end
       end
 
@@ -36,7 +36,11 @@ module Overcommit::Hook::PreCommit
       end
 
       def error_text_for(file)
-        "#{relative_path_for(file)} is over the size limit."
+        "#{relative_path_for(file)} is over the file size limit of #{size_limit_bytes} bytes (is #{file_size(file)} bytes)"
+      end
+
+      def file_size(file)
+        File.size(file)
       end
 
       def relative_path_for(file)

--- a/lib/overcommit/hook/pre_commit/file_size.rb
+++ b/lib/overcommit/hook/pre_commit/file_size.rb
@@ -1,0 +1,50 @@
+module Overcommit::Hook::PreCommit
+  class FileSize < Base
+    DEFAULT_SIZE_LIMIT_BYTES = 1_000_000 # 1MB
+
+    def run
+      return :pass if oversized_files.empty?
+
+      oversized_files.map do |file|
+        error_message_for(file)
+      end
+    end
+
+    private
+
+      def oversized_files
+        @_oversized_files ||= build_oversized_file_list
+      end
+
+      def build_oversized_file_list
+        applicable_files.select do |file|
+          File.size(file) > size_limit_bytes
+        end
+      end
+
+      def size_limit_bytes
+        config.fetch("size_limit_bytes", DEFAULT_SIZE_LIMIT_BYTES)
+      end
+
+      def error_message_for(file)
+        Overcommit::Hook::Message.new(
+          :error,
+          file,
+          nil,
+          error_text_for(file)
+        )
+      end
+
+      def error_text_for(file)
+        "#{relative_path_for(file)} is over the size limit."
+      end
+
+      def relative_path_for(file)
+        Pathname.new(file).relative_path_from(repo_root_path)
+      end
+
+      def repo_root_path
+        @_repo_root_path ||= Pathname.new(Overcommit::Utils.repo_root)
+      end
+  end
+end

--- a/lib/overcommit/hook/pre_commit/file_size.rb
+++ b/lib/overcommit/hook/pre_commit/file_size.rb
@@ -23,7 +23,7 @@ module Overcommit::Hook::PreCommit
 
     def build_oversized_file_list
       applicable_files.select do |file|
-        file_size(file) > size_limit_bytes
+        File.exist?(file) && file_size(file) > size_limit_bytes
       end
     end
 

--- a/lib/overcommit/hook/pre_commit/file_size.rb
+++ b/lib/overcommit/hook/pre_commit/file_size.rb
@@ -11,6 +11,10 @@ module Overcommit::Hook::PreCommit
       end
     end
 
+    def description
+      "Check for files over #{size_limit_bytes} bytes"
+    end
+
     private
 
     def oversized_files

--- a/spec/overcommit/hook/pre_commit/file_size_spec.rb
+++ b/spec/overcommit/hook/pre_commit/file_size_spec.rb
@@ -40,7 +40,7 @@ describe Overcommit::Hook::PreCommit::FileSize do
   context 'when a small file is committed' do
     let(:contents) { 'short' }
 
-    it { should_not fail_hook }
+    it { should pass }
   end
 
   context 'when a file is removed' do

--- a/spec/overcommit/hook/pre_commit/file_size_spec.rb
+++ b/spec/overcommit/hook/pre_commit/file_size_spec.rb
@@ -42,4 +42,16 @@ describe Overcommit::Hook::PreCommit::FileSize do
 
     it { should_not fail_hook }
   end
+
+  context 'when a file is removed' do
+    let(:contents) { 'anything' }
+    before do
+      `git commit -m "Add file"`
+      `git rm "#{staged_file}"`
+    end
+
+    it 'should not raise an exception' do
+      lambda { should pass }.should_not raise_error
+    end
+  end
 end

--- a/spec/overcommit/hook/pre_commit/file_size_spec.rb
+++ b/spec/overcommit/hook/pre_commit/file_size_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Overcommit::Hook::PreCommit::FileSize do
+  let(:config) do
+    Overcommit::ConfigurationLoader.default_configuration.merge(
+      Overcommit::Configuration.new(
+        'PreCommit' => {
+          'FileSize' => {
+            'size_limit_bytes' => 10
+          }
+        }
+      )
+    )
+  end
+
+  let(:context) { double('context') }
+  subject { described_class.new(config, context) }
+  let(:staged_file) { 'filename.txt' }
+
+  before do
+    subject.stub(:applicable_files).and_return([staged_file])
+  end
+
+  around do |example|
+    repo do
+      File.open(staged_file, 'w') { |f| f.write(contents) }
+      `git add "#{staged_file}" > #{File::NULL} 2>&1`
+      example.run
+    end
+  end
+
+  context 'when a big file is committed' do
+    let(:contents) { 'longer than 10 bytes' }
+
+    it { should fail_hook }
+  end
+
+  context 'when a small file is committed' do
+    let(:contents) { 'short' }
+
+    it { should_not fail_hook }
+  end
+end


### PR DESCRIPTION
Coming from https://github.com/brigade/overcommit/issues/348

After a few modifications from what I posted in the issue, the result is now this:

![image](https://user-images.githubusercontent.com/816901/56113169-067c7c00-5f98-11e9-9571-a46be1094f1e.png)

Note the file limit is now dynamically output in the hook's description so that it does not need to be repeated in each FileSize error.

Feel free to check the commit history to have an idea of my thinking process.

Improvements such as supporting file size units are welcome, but please let me suggest to open another PRs once this one is merged. 🙇 